### PR TITLE
[Kepler.gl] Fix file upload generating an infinite number of duplicated layers

### DIFF
--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -124,11 +124,16 @@ Imported data are imported with `processFileData` :
 Side effects should be handled _via_ `@reduxjs/toolkit` but first, you should ask yourself :
 
 1. If The action you want to dispatch is just here forward some data to your state, you might not need a side effect, see if it can be handled directly in one of your reducer instead:
-   - https://github.com/reduxjs/redux-toolkit/issues/1509#issuecomment-919255436
+
+- https://github.com/reduxjs/redux-toolkit/issues/1509#issuecomment-919255436
+
 2. If you need to wait for an API call to complete, you may just need to `dispatch` your side-effect in the `onQueryStarted` hook function.
-   - https://redux-toolkit.js.org/rtk-query/usage/queries
+
+- https://redux-toolkit.js.org/rtk-query/usage/queries
+
 3. Your side effects require a complex workflow, then use a custom `createListenerMiddleware`:
-   - https://redux-toolkit.js.org/api/createListenerMiddleware
+
+- https://redux-toolkit.js.org/api/createListenerMiddleware
 
 ### Compiling **Kepler.gl** from source
 
@@ -141,3 +146,11 @@ You might need to manually set your `c` compiler version to something older :
 ```
 CXX=g++-9 yarn
 ```
+
+### Advanced reducer customization
+
+Reducer `plugins` aren't made to replace an existing action.
+If a **Kepler.gl** action is faulty, you must recreate the reducer slice from scratch.
+Unfortunately, most of **Kepler.gl** objects aren't exported so you must duplicate it in your own source code.
+
+> See [./apps/frontend/src/store/reducers/keplerGl/vis-state.ts](./apps/frontend/src/store/reducers/keplerGl/vis-state.ts) for example.

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -129,3 +129,15 @@ Side effects should be handled _via_ `@reduxjs/toolkit` but first, you should as
    - https://redux-toolkit.js.org/rtk-query/usage/queries
 3. Your side effects require a complex workflow, then use a custom `createListenerMiddleware`:
    - https://redux-toolkit.js.org/api/createListenerMiddleware
+
+### Compiling **Kepler.gl** from source
+
+Downgrade to Node.js v16.
+
+> You mays use [**n**](https://github.com/tj/n) or \__nvm_ in order to do so.
+
+You might need to manually set your `c` compiler version to something older :
+
+```
+CXX=g++-9 yarn
+```

--- a/apps/frontend/src/store/actions.ts
+++ b/apps/frontend/src/store/actions.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import curry from 'lodash.curry';
+import { wrapTo } from 'kepler.gl/actions';
+
+export const wrapCreatorTo = curry(
+  (id, actionCreator) =>
+    (...args: any[]) =>
+      wrapTo(id)(actionCreator(...args))
+);

--- a/apps/frontend/src/store/effects.ts
+++ b/apps/frontend/src/store/effects.ts
@@ -14,7 +14,7 @@ interface KeplerWrappedAction extends AnyAction {
   };
 }
 
-const isAKeplerWrappedAction = (action: AnyAction): action is KeplerWrappedAction => action.payload.meta._id_;
+const isAKeplerWrappedAction = (action: AnyAction): action is KeplerWrappedAction => action.payload?.meta?._id_;
 
 const isOneOfTheseKeplerTypes =
   (types: string[]) =>
@@ -27,6 +27,7 @@ startAppListening({
       UPDATE_MAP_INFO,
       // '@@kepler.gl/UPDATE_MAP',
       '@@kepler.gl/ADD_DATA_TO_MAP',
+      '@@kepler.gl/LOAD_FILES_SUCCESS', // Loading data via a file upload
       '@@kepler.gl/REMOVE_DATASET',
       '@@kepler.gl/MAP_CONFIG_CHANGE',
       // Layers

--- a/apps/frontend/src/store/reducers/keplerGl/core.ts
+++ b/apps/frontend/src/store/reducers/keplerGl/core.ts
@@ -1,0 +1,26 @@
+import { combineReducers } from 'redux';
+import { mapStateReducerFactory } from 'kepler.gl/dist/reducers/map-state';
+import { mapStyleReducerFactory } from 'kepler.gl/dist/reducers/map-style';
+import { uiStateReducerFactory } from 'kepler.gl/dist/reducers/ui-state';
+import { providerStateReducerFactory } from 'kepler.gl/dist/reducers/provider-state';
+import composers from 'kepler.gl/dist/reducers/composers';
+import { KeplerGlState } from 'kepler.gl/reducers';
+import { visStateReducerFactory } from './vis-state';
+
+const combined = (initialState: KeplerGlState = {}) =>
+  combineReducers({
+    visState: visStateReducerFactory(initialState.visState),
+    mapState: mapStateReducerFactory(initialState.mapState),
+    mapStyle: mapStyleReducerFactory(initialState.mapStyle),
+    uiState: uiStateReducerFactory(initialState.uiState),
+    providerState: providerStateReducerFactory(initialState.providerState),
+  });
+
+export const coreReducerFactory =
+  (initialState = {}) =>
+  (state, action) => {
+    if (composers[action.type]) {
+      return composers[action.type](state, action);
+    }
+    return combined(initialState)(state, action);
+  };

--- a/apps/frontend/src/store/reducers/keplerGl/index.spec.ts
+++ b/apps/frontend/src/store/reducers/keplerGl/index.spec.ts
@@ -1,5 +1,5 @@
 import { generateFakeProjectDto } from '@datatlas/dtos';
-import { addProjectToKeplerState } from './keplerGl';
+import { addProjectToKeplerState } from './index';
 
 describe('addProjectToState', () => {
   it('add a project as new KeplerState slice in the state', () => {

--- a/apps/frontend/src/store/reducers/keplerGl/index.ts
+++ b/apps/frontend/src/store/reducers/keplerGl/index.ts
@@ -1,14 +1,15 @@
 /* eslint-disable no-useless-computed-key */
 import { AnyAction, createAction, Reducer } from '@reduxjs/toolkit';
 import { registerEntry } from 'kepler.gl';
-import keplerGlReducer, { KeplerGlState } from 'kepler.gl/reducers';
+import { KeplerGlState } from 'kepler.gl/reducers';
+import { keplerGlReducer } from './root';
 import { addDataToMap, setMapInfo, wrapTo, setLocale as setKeplerMapLocale } from 'kepler.gl/actions';
 import { DatatlasSavedMapInterface, Filter, KeplerMapState, KeplerMapStyle, MapInfoInterface } from '@datatlas/models';
 import { ProjectDto } from '@datatlas/dtos';
-import { getDefaultLocale } from '../../i18n/utils';
-import { getProject, getProjects } from '../api';
-import { keplerMapFactory, KeplerMapFactory } from '../../kepler';
-import { toKeplerId } from '../selectors';
+import { getDefaultLocale } from '../../../i18n/utils';
+import { getProject, getProjects } from '../../api';
+import { keplerMapFactory, KeplerMapFactory } from '../../../kepler';
+import { toKeplerId } from '../../selectors';
 import { INITIAL_VIS_STATE } from 'kepler.gl/dist/reducers/vis-state-updaters';
 import { DatatlasGlVisStateInterface, getDefaultInteractionConfig } from '@datatlas/models';
 
@@ -40,11 +41,11 @@ export const keplerReducer: Reducer<DatatlasGlState> = keplerGlReducer
       ...INITIAL_VIS_STATE,
       interactionConfig: getDefaultInteractionConfig(),
     },
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     mapStyle: new KeplerMapStyle({ mapboxApiAccessToken: process.env.REACT_APP_MAPBOX_ACCESS_TOKEN }),
   })
   .plugin({
+    // If you want to use an existing "updater" function, make sur to pass the right state slice as argument.
+    // Kepler lenses might be helpful for this.
     [UPDATE_MAP_INFO]: (state, action) => ({
       ...state,
       visState: {

--- a/apps/frontend/src/store/reducers/keplerGl/root.ts
+++ b/apps/frontend/src/store/reducers/keplerGl/root.ts
@@ -1,0 +1,117 @@
+import { handleActions } from 'redux-actions';
+import { _actionFor, _updateProperty } from 'kepler.gl/dist/actions/action-wrapper';
+import { keplerGlInit } from 'kepler.gl/dist/actions/actions';
+import { coreReducerFactory } from './core';
+import ActionTypes from 'kepler.gl/dist/constants/action-types';
+
+// INITIAL_STATE
+const initialCoreState = {};
+
+export function provideInitialState(initialState = {}) {
+  const coreReducer = coreReducerFactory(initialState);
+
+  const handleRegisterEntry = (
+    state,
+    { payload: { id, mint, mapboxApiAccessToken, mapboxApiUrl, mapStylesReplaceDefault, initialUiState } }
+  ) => {
+    // by default, always create a mint state even if the same id already exist
+    // if state.id exist and mint=false, keep the existing state
+    const previousState = state[id] && mint === false ? state[id] : undefined;
+
+    return {
+      // register entry to kepler.gl passing in mapbox config to mapStyle
+      ...state,
+      [id]: coreReducer(
+        previousState,
+        keplerGlInit({ mapboxApiAccessToken, mapboxApiUrl, mapStylesReplaceDefault, initialUiState })
+      ),
+    };
+  };
+
+  const handleDeleteEntry = (state, { payload: id }) =>
+    Object.keys(state).reduce(
+      (accu, curr) => ({
+        ...accu,
+        ...(curr === id ? {} : { [curr]: state[curr] }),
+      }),
+      {}
+    );
+
+  const handleRenameEntry = (state, { payload: { oldId, newId } }) =>
+    Object.keys(state).reduce(
+      (accu, curr) => ({
+        ...accu,
+        ...{ [curr === oldId ? newId : curr]: state[curr] },
+      }),
+      {}
+    );
+
+  return (state = initialCoreState, action) => {
+    // update child states
+    Object.keys(state).forEach((id) => {
+      const updateItemState = coreReducer(state[id], _actionFor(id, action));
+      state = _updateProperty(state, id, updateItemState);
+    });
+
+    // perform additional state reducing (e.g. switch action.type etc...)
+    const handlers = {
+      [ActionTypes.REGISTER_ENTRY]: handleRegisterEntry,
+      [ActionTypes.DELETE_ENTRY]: handleDeleteEntry,
+      [ActionTypes.RENAME_ENTRY]: handleRenameEntry,
+    };
+
+    return handleActions(handlers, initialCoreState)(state, action);
+  };
+}
+
+const _keplerGlReducer = provideInitialState();
+
+function mergeInitialState(saved = {}, provided = {}) {
+  const keys = ['mapState', 'mapStyle', 'visState', 'uiState'];
+
+  // shallow merge each reducer
+  return keys.reduce(
+    (accu, key) => ({
+      ...accu,
+      ...(saved[key] && provided[key]
+        ? { [key]: { ...saved[key], ...provided[key] } }
+        : { [key]: saved[key] || provided[key] || {} }),
+    }),
+    {}
+  );
+}
+
+function decorate(target, savedInitialState = {}) {
+  const targetInitialState = savedInitialState;
+
+  target.plugin = function plugin(customReducer) {
+    if (typeof customReducer === 'object') {
+      // if only provided a reducerMap, wrap it in a reducer
+      customReducer = handleActions(customReducer, {});
+    }
+
+    // use 'function' keyword to enable 'this'
+    return decorate((state = {}, action = {}) => {
+      let nextState = this(state, action);
+
+      // for each entry in the staten
+      Object.keys(nextState).forEach((id) => {
+        // update child states
+        nextState = _updateProperty(nextState, id, customReducer(nextState[id], _actionFor(id, action)));
+      });
+
+      return nextState;
+    });
+  };
+
+  target.initialState = function initialState(iniSt) {
+    const merged = mergeInitialState(targetInitialState, iniSt);
+    const targetReducer = provideInitialState(merged);
+
+    return decorate(targetReducer, merged);
+  };
+
+  return target;
+}
+
+export const keplerGlReducer = decorate(_keplerGlReducer);

--- a/apps/frontend/src/store/reducers/keplerGl/vis-state-updaters.ts
+++ b/apps/frontend/src/store/reducers/keplerGl/vis-state-updaters.ts
@@ -1,0 +1,136 @@
+import { withTask } from 'react-palm/tasks';
+import { LOAD_FILE_TASK, UNWRAP_TASK, DELAY_TASK } from 'kepler.gl/dist/tasks/tasks';
+import {
+  initialFileLoadingProgress,
+  updateFileLoadingProgressUpdater,
+  parseProgress,
+} from 'kepler.gl/dist/reducers/vis-state-updaters';
+import { merge_, pick_ } from 'kepler.gl/dist/reducers/composer-helpers';
+import {
+  loadFilesSuccess,
+  loadFilesErr,
+  nextFileBatch,
+  processFileContent,
+  loadNextFile,
+  wrapTo,
+} from 'kepler.gl/actions';
+import { wrapCreatorTo } from '../../actions';
+
+export const loadFilesUpdater = (state, action) => {
+  const instanceId = action.meta._id_;
+  const { files, onFinish = wrapCreatorTo(instanceId, loadFilesSuccess) } = action;
+
+  if (!files.length) {
+    return state;
+  }
+
+  const fileLoadingProgress = Array.from(files).reduce(
+    (accu, f, i) => merge_(initialFileLoadingProgress(f, i))(accu),
+    {}
+  );
+
+  const fileLoading = {
+    fileCache: [],
+    filesToLoad: files,
+    onFinish,
+  };
+
+  const nextState = merge_({ fileLoadingProgress, fileLoading })(state);
+
+  return loadNextFileUpdater(nextState, instanceId);
+};
+
+export function loadNextFileUpdater(state, instanceId?: number) {
+  if (!state.fileLoading) {
+    return state;
+  }
+  const { filesToLoad } = state.fileLoading;
+  const [file, ...remainingFilesToLoad] = filesToLoad;
+
+  // save filesToLoad to state
+  const nextState = pick_('fileLoading')(merge_({ filesToLoad: remainingFilesToLoad }))(state);
+
+  const stateWithProgress = updateFileLoadingProgressUpdater(nextState, {
+    fileName: file.name,
+    progress: { percent: 0, message: 'loading...' },
+  });
+
+  const { loaders, loadOptions } = state;
+  return withTask(
+    stateWithProgress,
+    makeLoadFileTask(file, nextState.fileLoading.fileCache, loaders, loadOptions, instanceId)
+  );
+}
+
+export function makeLoadFileTask(file, fileCache, loaders = [], loadOptions = {}, instanceId?: number) {
+  return LOAD_FILE_TASK({ file, fileCache, loaders, loadOptions }).bimap(
+    // prettier ignore
+    // success
+    (gen) =>
+      wrapTo(instanceId)(
+        nextFileBatch({
+          gen,
+          fileName: file.name,
+          onFinish: (result) =>
+            wrapTo(instanceId)(
+              processFileContent({
+                content: result,
+                fileCache,
+              })
+            ),
+        })
+      ),
+
+    // error
+    (err) => loadFilesErr(file.name, err)
+  );
+}
+
+export const nextFileBatchUpdater = (
+  state,
+  { payload: { gen, fileName, progress, accumulated, onFinish }, meta: { _id_ } }
+) => {
+  const stateWithProgress = updateFileLoadingProgressUpdater(state, {
+    fileName,
+    progress: parseProgress(state.fileLoadingProgress[fileName], progress),
+  });
+  return withTask(
+    stateWithProgress,
+    UNWRAP_TASK(gen.next()).bimap(
+      ({ value, done }) => {
+        return done
+          ? onFinish(accumulated)
+          : wrapTo(_id_)(
+              nextFileBatch({
+                gen,
+                fileName,
+                progress: value.progress,
+                accumulated: value,
+                onFinish,
+              })
+            );
+      },
+      (err) => wrapTo(_id_)(loadFilesErr(fileName, err))
+    )
+  );
+};
+
+export const loadFilesErrUpdater = (state, { error, fileName, meta: { _id_ } }) => {
+  // update ui with error message
+  console.warn(error);
+  if (!state.fileLoading) {
+    return state;
+  }
+  const { filesToLoad, onFinish, fileCache } = state.fileLoading;
+
+  const nextState = updateFileLoadingProgressUpdater(state, {
+    fileName,
+    progress: { error },
+  });
+
+  // kick off next file or finish
+  return withTask(
+    nextState,
+    DELAY_TASK(200).map(filesToLoad.length ? wrapCreatorTo(_id_, loadNextFile) : () => onFinish(fileCache))
+  );
+};

--- a/apps/frontend/src/store/reducers/keplerGl/vis-state.ts
+++ b/apps/frontend/src/store/reducers/keplerGl/vis-state.ts
@@ -1,0 +1,78 @@
+import ActionTypes from 'kepler.gl/dist/constants/action-types';
+import { handleActions } from 'redux-actions';
+import * as keplerGlVisStateUpdaters from 'kepler.gl/dist/reducers/vis-state-updaters';
+import { loadFilesUpdater, loadNextFileUpdater, nextFileBatchUpdater } from './vis-state-updaters';
+
+/**
+ * Important: Do not rename `actionHandler` or the assignment pattern of property value.
+ * It is used to generate documentation
+ */
+const actionHandler = {
+  [ActionTypes.ADD_FILTER]: keplerGlVisStateUpdaters.addFilterUpdater,
+  [ActionTypes.ADD_LAYER]: keplerGlVisStateUpdaters.addLayerUpdater,
+  [ActionTypes.DUPLICATE_LAYER]: keplerGlVisStateUpdaters.duplicateLayerUpdater,
+  [ActionTypes.ENLARGE_FILTER]: keplerGlVisStateUpdaters.enlargeFilterUpdater,
+  [ActionTypes.INTERACTION_CONFIG_CHANGE]: keplerGlVisStateUpdaters.interactionConfigChangeUpdater,
+  [ActionTypes.LAYER_CLICK]: keplerGlVisStateUpdaters.layerClickUpdater,
+  [ActionTypes.LAYER_CONFIG_CHANGE]: keplerGlVisStateUpdaters.layerConfigChangeUpdater,
+  [ActionTypes.LAYER_HOVER]: keplerGlVisStateUpdaters.layerHoverUpdater,
+  [ActionTypes.LAYER_TYPE_CHANGE]: keplerGlVisStateUpdaters.layerTypeChangeUpdater,
+  [ActionTypes.LAYER_VIS_CONFIG_CHANGE]: keplerGlVisStateUpdaters.layerVisConfigChangeUpdater,
+  [ActionTypes.LAYER_TEXT_LABEL_CHANGE]: keplerGlVisStateUpdaters.layerTextLabelChangeUpdater,
+  [ActionTypes.LAYER_VISUAL_CHANNEL_CHANGE]: keplerGlVisStateUpdaters.layerVisualChannelChangeUpdater,
+  [ActionTypes.LAYER_COLOR_UI_CHANGE]: keplerGlVisStateUpdaters.layerColorUIChangeUpdater,
+  [ActionTypes.TOGGLE_LAYER_ANIMATION]: keplerGlVisStateUpdaters.toggleLayerAnimationUpdater,
+  [ActionTypes.TOGGLE_LAYER_ANIMATION_CONTROL]: keplerGlVisStateUpdaters.toggleLayerAnimationControlUpdater,
+  [ActionTypes.LOAD_FILES]: loadFilesUpdater,
+  [ActionTypes.LOAD_FILES_ERR]: keplerGlVisStateUpdaters.loadFilesErrUpdater,
+  [ActionTypes.LOAD_NEXT_FILE]: loadNextFileUpdater,
+  [ActionTypes.LOAD_FILE_STEP_SUCCESS]: keplerGlVisStateUpdaters.loadFileStepSuccessUpdater,
+  [ActionTypes.MAP_CLICK]: keplerGlVisStateUpdaters.mapClickUpdater,
+  [ActionTypes.MOUSE_MOVE]: keplerGlVisStateUpdaters.mouseMoveUpdater,
+  [ActionTypes.RECEIVE_MAP_CONFIG]: keplerGlVisStateUpdaters.receiveMapConfigUpdater,
+  [ActionTypes.REMOVE_DATASET]: keplerGlVisStateUpdaters.removeDatasetUpdater,
+  [ActionTypes.REMOVE_FILTER]: keplerGlVisStateUpdaters.removeFilterUpdater,
+  [ActionTypes.REMOVE_LAYER]: keplerGlVisStateUpdaters.removeLayerUpdater,
+  [ActionTypes.REORDER_LAYER]: keplerGlVisStateUpdaters.reorderLayerUpdater,
+  [ActionTypes.RESET_MAP_CONFIG]: keplerGlVisStateUpdaters.resetMapConfigUpdater,
+  [ActionTypes.SET_FILTER]: keplerGlVisStateUpdaters.setFilterUpdater,
+  [ActionTypes.SET_FILTER_ANIMATION_TIME]: keplerGlVisStateUpdaters.setFilterAnimationTimeUpdater,
+  [ActionTypes.SET_FILTER_ANIMATION_TIME_CONFIG]: keplerGlVisStateUpdaters.setFilterAnimationTimeConfigUpdater,
+  [ActionTypes.SET_FILTER_ANIMATION_WINDOW]: keplerGlVisStateUpdaters.setFilterAnimationWindowUpdater,
+  [ActionTypes.SET_FILTER_PLOT]: keplerGlVisStateUpdaters.setFilterPlotUpdater,
+  [ActionTypes.SET_MAP_INFO]: keplerGlVisStateUpdaters.setMapInfoUpdater,
+  [ActionTypes.SHOW_DATASET_TABLE]: keplerGlVisStateUpdaters.showDatasetTableUpdater,
+  [ActionTypes.TOGGLE_FILTER_ANIMATION]: keplerGlVisStateUpdaters.toggleFilterAnimationUpdater,
+  [ActionTypes.UPDATE_FILTER_ANIMATION_SPEED]: keplerGlVisStateUpdaters.updateFilterAnimationSpeedUpdater,
+  [ActionTypes.SET_LAYER_ANIMATION_TIME]: keplerGlVisStateUpdaters.setLayerAnimationTimeUpdater,
+  [ActionTypes.UPDATE_LAYER_ANIMATION_SPEED]: keplerGlVisStateUpdaters.updateLayerAnimationSpeedUpdater,
+  [ActionTypes.TOGGLE_LAYER_FOR_MAP]: keplerGlVisStateUpdaters.toggleLayerForMapUpdater,
+  [ActionTypes.TOGGLE_SPLIT_MAP]: keplerGlVisStateUpdaters.toggleSplitMapUpdater,
+  [ActionTypes.UPDATE_LAYER_BLENDING]: keplerGlVisStateUpdaters.updateLayerBlendingUpdater,
+  [ActionTypes.UPDATE_VIS_DATA]: keplerGlVisStateUpdaters.updateVisDataUpdater,
+  [ActionTypes.RENAME_DATASET]: keplerGlVisStateUpdaters.renameDatasetUpdater,
+  [ActionTypes.SET_FEATURES]: keplerGlVisStateUpdaters.setFeaturesUpdater,
+  [ActionTypes.DELETE_FEATURE]: keplerGlVisStateUpdaters.deleteFeatureUpdater,
+  [ActionTypes.SET_POLYGON_FILTER_LAYER]: keplerGlVisStateUpdaters.setPolygonFilterLayerUpdater,
+  [ActionTypes.SET_SELECTED_FEATURE]: keplerGlVisStateUpdaters.setSelectedFeatureUpdater,
+  [ActionTypes.SET_EDITOR_MODE]: keplerGlVisStateUpdaters.setEditorModeUpdater,
+  [ActionTypes.TOGGLE_EDITOR_VISIBILITY]: keplerGlVisStateUpdaters.toggleEditorVisibilityUpdater,
+  [ActionTypes.TOGGLE_FILTER_FEATURE]: keplerGlVisStateUpdaters.toggleFilterFeatureUpdater,
+  [ActionTypes.APPLY_CPU_FILTER]: keplerGlVisStateUpdaters.applyCPUFilterUpdater,
+  [ActionTypes.SORT_TABLE_COLUMN]: keplerGlVisStateUpdaters.sortTableColumnUpdater,
+  [ActionTypes.PIN_TABLE_COLUMN]: keplerGlVisStateUpdaters.pinTableColumnUpdater,
+  [ActionTypes.COPY_TABLE_COLUMN]: keplerGlVisStateUpdaters.copyTableColumnUpdater,
+  [ActionTypes.NEXT_FILE_BATCH]: nextFileBatchUpdater,
+  [ActionTypes.PROCESS_FILE_CONTENT]: keplerGlVisStateUpdaters.processFileContentUpdater,
+  [ActionTypes.SET_LAYER_ANIMATION_TIME_CONFIG]: keplerGlVisStateUpdaters.setLayerAnimationTimeConfigUpdater,
+};
+
+// construct vis-state reducer
+export const visStateReducerFactory = (initialState = {}) =>
+  handleActions(actionHandler, {
+    ...keplerGlVisStateUpdaters.INITIAL_VIS_STATE,
+    ...initialState,
+    initialState,
+  });
+
+export default visStateReducerFactory();

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "react-hook-form": "^7.42.1",
         "react-intl": "^3.12.1",
         "react-is": "18.2.0",
+        "react-palm": "^3.3.8",
         "react-router": "^6.6.2",
         "react-router-dom": "6.4.3",
         "react-sortable-hoc": "^1.11.0",
@@ -139,6 +140,9 @@
         "vitest": "^0.25.8",
         "web-vitals": "^3.1.0",
         "whatwg-fetch": "^3.6.2"
+      },
+      "engines": {
+        "node": ">=16 <17"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -18734,6 +18738,65 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/enzyme-adapter-utils": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.1.tgz",
+      "integrity": "sha512-JZgMPF1QOI7IzBj24EZoDpaeG/p8Os7WeBZWTJydpsH7JRStc7jYbHE4CmNQaLqazaGFyLM8ALWA3IIZvxW3PQ==",
+      "peer": true,
+      "dependencies": {
+        "airbnb-prop-types": "^2.16.0",
+        "function.prototype.name": "^1.1.5",
+        "has": "^1.0.3",
+        "object.assign": "^4.1.4",
+        "object.fromentries": "^2.0.5",
+        "prop-types": "^15.8.1",
+        "semver": "^5.7.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "peerDependencies": {
+        "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"
+      }
+    },
+    "node_modules/enzyme-adapter-utils/node_modules/airbnb-prop-types": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
+      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
+      "peer": true,
+      "dependencies": {
+        "array.prototype.find": "^2.1.1",
+        "function.prototype.name": "^1.1.2",
+        "is-regex": "^1.1.0",
+        "object-is": "^1.1.2",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.2",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.13.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "peerDependencies": {
+        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
+      }
+    },
+    "node_modules/enzyme-adapter-utils/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "peer": true
+    },
+    "node_modules/enzyme-adapter-utils/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/enzyme-shallow-equal": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.5.tgz",
@@ -29179,50 +29242,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/kepler.gl/node_modules/enzyme-adapter-utils": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.1.tgz",
-      "integrity": "sha512-JZgMPF1QOI7IzBj24EZoDpaeG/p8Os7WeBZWTJydpsH7JRStc7jYbHE4CmNQaLqazaGFyLM8ALWA3IIZvxW3PQ==",
-      "peer": true,
-      "dependencies": {
-        "airbnb-prop-types": "^2.16.0",
-        "function.prototype.name": "^1.1.5",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.4",
-        "object.fromentries": "^2.0.5",
-        "prop-types": "^15.8.1",
-        "semver": "^5.7.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"
-      }
-    },
-    "node_modules/kepler.gl/node_modules/enzyme-adapter-utils/node_modules/airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "peer": true,
-      "dependencies": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
-      }
-    },
     "node_modules/kepler.gl/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -29346,11 +29365,6 @@
         "renderkid": "^2.0.4"
       }
     },
-    "node_modules/kepler.gl/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/kepler.gl/node_modules/react-map-gl-draw": {
       "version": "0.14.8",
       "resolved": "https://registry.npmjs.org/react-map-gl-draw/-/react-map-gl-draw-0.14.8.tgz",
@@ -29367,68 +29381,6 @@
         "react": "0.14.x - 16.x",
         "react-dom": "0.14.x - 16.x",
         "react-map-gl": ">=4.0.0"
-      }
-    },
-    "node_modules/kepler.gl/node_modules/react-palm": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/react-palm/-/react-palm-3.3.8.tgz",
-      "integrity": "sha512-xKh5X5y7zJ4XJid4ZCKCqBdjEWxM4R3UKonhoSgxoKmpqHsm/PpyKiZIlZ0dssmhppABrN+u4MRFALjJmFb3Uw==",
-      "dependencies": {
-        "function.prototype.name": "^1.1.0",
-        "react-dom": "^16.4.2",
-        "react-reconciler": "^0.12.0",
-        "react-test-renderer": "^16.4.2"
-      },
-      "peerDependencies": {
-        "enzyme": "^3.6.0",
-        "enzyme-adapter-utils": "^1.13.0",
-        "react": "^16.4.1",
-        "react-test-renderer": "^16.4.1"
-      }
-    },
-    "node_modules/kepler.gl/node_modules/react-palm/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/kepler.gl/node_modules/react-palm/node_modules/react-reconciler": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.12.0.tgz",
-      "integrity": "sha512-BBaE+asD1HdzS35GLhvOEUGFwFKBNN/Jj9b+VlCt9JjF+jDnmIij4SbulNpqccYxPE/Eeup3/ciouo9YmhSgbg==",
-      "dependencies": {
-        "fbjs": "^0.8.16",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0"
-      }
-    },
-    "node_modules/kepler.gl/node_modules/react-palm/node_modules/react-test-renderer": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
       }
     },
     "node_modules/kepler.gl/node_modules/react-vis": {
@@ -29515,24 +29467,6 @@
         "htmlparser2": "^6.1.0",
         "lodash": "^4.17.21",
         "strip-ansi": "^3.0.1"
-      }
-    },
-    "node_modules/kepler.gl/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/kepler.gl/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/kepler.gl/node_modules/source-map": {
@@ -35227,6 +35161,82 @@
       "peerDependencies": {
         "react": "^15.5.x || ^16.x || ^17.x || ^18.x",
         "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
+      }
+    },
+    "node_modules/react-palm": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/react-palm/-/react-palm-3.3.8.tgz",
+      "integrity": "sha512-xKh5X5y7zJ4XJid4ZCKCqBdjEWxM4R3UKonhoSgxoKmpqHsm/PpyKiZIlZ0dssmhppABrN+u4MRFALjJmFb3Uw==",
+      "dependencies": {
+        "function.prototype.name": "^1.1.0",
+        "react-dom": "^16.4.2",
+        "react-reconciler": "^0.12.0",
+        "react-test-renderer": "^16.4.2"
+      },
+      "peerDependencies": {
+        "enzyme": "^3.6.0",
+        "enzyme-adapter-utils": "^1.13.0",
+        "react": "^16.4.1",
+        "react-test-renderer": "^16.4.1"
+      }
+    },
+    "node_modules/react-palm/node_modules/react-dom": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
+    "node_modules/react-palm/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-palm/node_modules/react-reconciler": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.12.0.tgz",
+      "integrity": "sha512-BBaE+asD1HdzS35GLhvOEUGFwFKBNN/Jj9b+VlCt9JjF+jDnmIij4SbulNpqccYxPE/Eeup3/ciouo9YmhSgbg==",
+      "dependencies": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0"
+      }
+    },
+    "node_modules/react-palm/node_modules/react-test-renderer": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.19.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0"
+      }
+    },
+    "node_modules/react-palm/node_modules/scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
       }
     },
     "node_modules/react-redux": {
@@ -58556,6 +58566,52 @@
         "string.prototype.trim": "^1.2.1"
       }
     },
+    "enzyme-adapter-utils": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.1.tgz",
+      "integrity": "sha512-JZgMPF1QOI7IzBj24EZoDpaeG/p8Os7WeBZWTJydpsH7JRStc7jYbHE4CmNQaLqazaGFyLM8ALWA3IIZvxW3PQ==",
+      "peer": true,
+      "requires": {
+        "airbnb-prop-types": "^2.16.0",
+        "function.prototype.name": "^1.1.5",
+        "has": "^1.0.3",
+        "object.assign": "^4.1.4",
+        "object.fromentries": "^2.0.5",
+        "prop-types": "^15.8.1",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "airbnb-prop-types": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
+          "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
+          "peer": true,
+          "requires": {
+            "array.prototype.find": "^2.1.1",
+            "function.prototype.name": "^1.1.2",
+            "is-regex": "^1.1.0",
+            "object-is": "^1.1.2",
+            "object.assign": "^4.1.0",
+            "object.entries": "^1.1.2",
+            "prop-types": "^15.7.2",
+            "prop-types-exact": "^1.2.0",
+            "react-is": "^16.13.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "peer": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "peer": true
+        }
+      }
+    },
     "enzyme-shallow-equal": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.5.tgz",
@@ -66542,40 +66598,6 @@
           "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
           "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         },
-        "enzyme-adapter-utils": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.1.tgz",
-          "integrity": "sha512-JZgMPF1QOI7IzBj24EZoDpaeG/p8Os7WeBZWTJydpsH7JRStc7jYbHE4CmNQaLqazaGFyLM8ALWA3IIZvxW3PQ==",
-          "peer": true,
-          "requires": {
-            "airbnb-prop-types": "^2.16.0",
-            "function.prototype.name": "^1.1.5",
-            "has": "^1.0.3",
-            "object.assign": "^4.1.4",
-            "object.fromentries": "^2.0.5",
-            "prop-types": "^15.8.1",
-            "semver": "^5.7.1"
-          },
-          "dependencies": {
-            "airbnb-prop-types": {
-              "version": "2.16.0",
-              "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-              "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-              "peer": true,
-              "requires": {
-                "array.prototype.find": "^2.1.1",
-                "function.prototype.name": "^1.1.2",
-                "is-regex": "^1.1.0",
-                "object-is": "^1.1.2",
-                "object.assign": "^4.1.0",
-                "object.entries": "^1.1.2",
-                "prop-types": "^15.7.2",
-                "prop-types-exact": "^1.2.0",
-                "react-is": "^16.13.1"
-              }
-            }
-          }
-        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -66668,11 +66690,6 @@
             "renderkid": "^2.0.4"
           }
         },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
         "react-map-gl-draw": {
           "version": "0.14.8",
           "resolved": "https://registry.npmjs.org/react-map-gl-draw/-/react-map-gl-draw-0.14.8.tgz",
@@ -66684,52 +66701,6 @@
             "prop-types": "^15.5.7",
             "uuid": "^3.3.2",
             "viewport-mercator-project": ">=5.0.0"
-          }
-        },
-        "react-palm": {
-          "version": "3.3.8",
-          "resolved": "https://registry.npmjs.org/react-palm/-/react-palm-3.3.8.tgz",
-          "integrity": "sha512-xKh5X5y7zJ4XJid4ZCKCqBdjEWxM4R3UKonhoSgxoKmpqHsm/PpyKiZIlZ0dssmhppABrN+u4MRFALjJmFb3Uw==",
-          "requires": {
-            "function.prototype.name": "^1.1.0",
-            "react-dom": "^16.4.2",
-            "react-reconciler": "^0.12.0",
-            "react-test-renderer": "^16.4.2"
-          },
-          "dependencies": {
-            "react-dom": {
-              "version": "16.14.0",
-              "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-              "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.19.1"
-              }
-            },
-            "react-reconciler": {
-              "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.12.0.tgz",
-              "integrity": "sha512-BBaE+asD1HdzS35GLhvOEUGFwFKBNN/Jj9b+VlCt9JjF+jDnmIij4SbulNpqccYxPE/Eeup3/ciouo9YmhSgbg==",
-              "requires": {
-                "fbjs": "^0.8.16",
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.0"
-              }
-            },
-            "react-test-renderer": {
-              "version": "16.14.0",
-              "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-              "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
-              "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "react-is": "^16.8.6",
-                "scheduler": "^0.19.1"
-              }
-            }
           }
         },
         "react-vis": {
@@ -66809,21 +66780,6 @@
             "lodash": "^4.17.21",
             "strip-ansi": "^3.0.1"
           }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "peer": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -70839,6 +70795,66 @@
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.12.2.tgz",
       "integrity": "sha512-NMXGa223OnsrGVp5dJHkuKxQ4czdLmXSp5jSV9OqiCky9LOpPATn3vLldc+q5fK3gKbEHvr7J1u0yhBh/xYkpA==",
       "requires": {}
+    },
+    "react-palm": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/react-palm/-/react-palm-3.3.8.tgz",
+      "integrity": "sha512-xKh5X5y7zJ4XJid4ZCKCqBdjEWxM4R3UKonhoSgxoKmpqHsm/PpyKiZIlZ0dssmhppABrN+u4MRFALjJmFb3Uw==",
+      "requires": {
+        "function.prototype.name": "^1.1.0",
+        "react-dom": "^16.4.2",
+        "react-reconciler": "^0.12.0",
+        "react-test-renderer": "^16.4.2"
+      },
+      "dependencies": {
+        "react-dom": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-reconciler": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.12.0.tgz",
+          "integrity": "sha512-BBaE+asD1HdzS35GLhvOEUGFwFKBNN/Jj9b+VlCt9JjF+jDnmIij4SbulNpqccYxPE/Eeup3/ciouo9YmhSgbg==",
+          "requires": {
+            "fbjs": "^0.8.16",
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "react-test-renderer": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+          "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+          "requires": {
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "react-is": "^16.8.6",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
     },
     "react-redux": {
       "version": "7.2.9",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "datatlas",
+  "engines": {
+    "node": ">=16 <=18"
+  },
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
@@ -132,6 +135,7 @@
     "react-hook-form": "^7.42.1",
     "react-intl": "^3.12.1",
     "react-is": "18.2.0",
+    "react-palm": "^3.3.8",
     "react-router": "^6.6.2",
     "react-router-dom": "6.4.3",
     "react-sortable-hoc": "^1.11.0",


### PR DESCRIPTION
> fix #209 & probably also fix #210

File upload related actions weren't scoped to a __Kepler.gl__ instance slice.
We had to internalize a big part of the `visState` and root reducer code to override the related state `updaters`.

> *This bug could easily be fixed by a simple contribution to __Kepler.gl__, we'll probably give it a shot someday but with no great expectations.*