### PR TITLE
feat(data-import): change available loaders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,4 @@ PASSWORD_SALT=put_long_string_here
 
 # FRONTEND
 REACT_APP_MAPBOX_ACCESS_TOKEN="defaultMapboxToken"
+REACT_APP_CONTACT_EMAIL=me@example.org

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,3 +1,4 @@
 REACT_APP_MAPBOX_ACCESS_TOKEN="token"
 REACT_APP_DEFAULT_LOCALE='fr'
 REACT_APP_API_BASE_URL=http://localhost:3333/api
+REACT_APP_CONTACT_EMAIL=me@frontend.example.org

--- a/apps/frontend/.eslintrc.json
+++ b/apps/frontend/.eslintrc.json
@@ -8,7 +8,9 @@
     },
     {
       "files": ["*.ts", "*.tsx"],
-      "rules": {}
+      "rules": {
+        "@typescript-eslint/ban-ts-comment": "off"
+      }
     },
     {
       "files": ["*.js", "*.jsx"],

--- a/apps/frontend/src/__mocks__/react-markdown.tsx
+++ b/apps/frontend/src/__mocks__/react-markdown.tsx
@@ -1,0 +1,5 @@
+function ReactMarkdown({ children }) {
+  return children;
+}
+
+export default ReactMarkdown;

--- a/apps/frontend/src/components/forms/LoadRemoteDatasetForm.tsx
+++ b/apps/frontend/src/components/forms/LoadRemoteDatasetForm.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useForm } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import { useSelector } from 'react-redux';
 import styled, { ThemeProps } from 'styled-components';
 import { addDataToMap } from 'kepler.gl/actions';
 import { DatasetFactory, DatasetInterface } from '@datatlas/models';
 import { DatatlasTheme } from '../../style/theme';
 import { isValidHttpURL } from '../../utils/url';
 import { useForward } from '../../hooks/useForward';
-
-export const CORS_LINK = 'https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS';
+import { markdownComponents } from '../markdown';
+import { GUIDES_FILE_FORMAT_DOC } from 'kepler.gl/dist/constants/user-guides';
+import { RootState } from '../../store/reducers';
+import { selectFileFormatNamesByInstanceId } from '../../store/selectors';
 
 const InputForm = styled.form`
   flex-grow: 1;
@@ -84,6 +89,10 @@ export function LoadRemoteDatasetForm() {
   const forward = useForward();
   const intl = useIntl();
 
+  // @todo We should overwrite the ModalFactory and inject `fileFormatNames` there instead.
+  const { id } = useParams();
+  const fileFormatNames = useSelector((state: RootState) => selectFileFormatNamesByInstanceId(state, id));
+
   const onSubmit = async () => {
     try {
       forward(
@@ -106,22 +115,21 @@ export function LoadRemoteDatasetForm() {
   return (
     <InputForm onSubmit={handleSubmit(onSubmit)}>
       <StyledDescription>
-        <FormattedMessage id={'loadRemoteData.description'} />
+        <ReactMarkdown
+          components={markdownComponents}
+          children={intl.formatMessage(
+            {
+              id: 'loadRemoteData.description',
+            },
+            {
+              fileFormatNames: fileFormatNames.map((format) => `**${format}**`).join(', '),
+              fileFormatDocLink: GUIDES_FILE_FORMAT_DOC,
+              contactEmail: process.env.REACT_APP_CONTACT_EMAIL,
+            }
+          )}
+          linkTarget="_blank"
+        />
       </StyledDescription>
-      <StyledInputLabel>
-        <FormattedMessage id={'loadRemoteData.message'} />
-      </StyledInputLabel>
-      <StyledInputLabel>
-        <FormattedMessage id={'loadRemoteData.examples'} />
-        <ul>
-          <li>https://your.map.url/map.json</li>
-          <li>http://your.map.url/data.csv</li>
-        </ul>
-      </StyledInputLabel>
-      <StyledInputLabel>
-        <FormattedMessage id={'loadRemoteData.cors'} />{' '}
-        <FormattedMessage id={'loadRemoteData.clickHere'} values={{ corsLink: CORS_LINK }} />
-      </StyledInputLabel>
       <StyledFromGroup>
         <StyledInput
           id="url"

--- a/apps/frontend/src/components/keplerGl/factories/LayerManagerFactory.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/LayerManagerFactory.tsx
@@ -114,16 +114,6 @@ const LayerManagerFactory = (
             <Warning stroke={themeColors.greyMedium} />
             <FormattedMessage id={'layerManager.dataWeight'} />
           </HintText>
-
-          <p>
-            <FormattedMessage id={'layerManager.fileFormat'} />
-          </p>
-          <p>
-            <FormattedMessage
-              id={'layerManager.contactUs'}
-              values={{ link: <a href={'https://data.grandlyon.com/'}>Contactez-nous</a> }}
-            />
-          </p>
         </StyledSidePanelSection>
         <SortableLayerList
           layers={layers}

--- a/apps/frontend/src/components/keplerGl/factories/LoadDataModalFactory.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/LoadDataModalFactory.tsx
@@ -11,11 +11,7 @@ const LoadDataModalFactory = (...deps) => {
 
   LoadDataModal.defaultProps = {
     ...LoadDataModal.defaultProps,
-    loadingMethods: [
-      remoteLoadingMethod,
-      LoadDataModal.defaultProps.loadingMethods.find((lm) => lm.id === 'upload'),
-      LoadDataModal.defaultProps.loadingMethods.find((lm) => lm.id === 'storage'),
-    ],
+    loadingMethods: [remoteLoadingMethod, LoadDataModal.defaultProps.loadingMethods.find((lm) => lm.id === 'upload')],
   };
 
   return LoadDataModal;

--- a/apps/frontend/src/components/keplerGl/factories/common/file-upload/FileUploadFactory.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/common/file-upload/FileUploadFactory.tsx
@@ -1,0 +1,294 @@
+/* eslint-disable react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
+// @see kepler.gl/src/components/common/file-uploader/file-upload
+import React, { createRef, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { FormattedMessage, useIntl } from 'react-intl';
+import ReactMarkdown from 'react-markdown';
+import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import UploadButton from 'kepler.gl/dist/components/common/file-uploader/upload-button';
+import { DragNDrop, FileType } from 'kepler.gl/dist/components/common/icons';
+import FileUploadProgress from 'kepler.gl/dist/components/common/file-uploader/file-upload-progress';
+import FileDrop from 'kepler.gl/dist/components/common/file-uploader/file-drop';
+import { isChrome } from 'kepler.gl/dist/utils/utils';
+import { GUIDES_FILE_FORMAT_DOC } from 'kepler.gl/dist/constants/user-guides';
+import { media } from 'kepler.gl/dist/styles/media-breakpoints';
+import { visStateActions } from 'kepler.gl/actions';
+import { FileUploadFactory as KeplerFileUploadFactory } from 'kepler.gl/dist/components';
+import { DatatlasTheme } from '../../../../../style/theme';
+import { markdownComponents } from '../../../../markdown';
+import { selectFileFormatNamesByInstanceId } from '../../../../../store/selectors';
+import { RootState } from '../../../../../store/reducers';
+
+const fileIconColor = '#D3D8E0';
+
+const StyledUploadMessage = styled.div`
+  color: ${(props) => props.theme.textColorLT};
+  font-size: 14px;
+  margin-bottom: 12px;
+
+  ${media.portable`
+    font-size: 12px;
+  `};
+`;
+
+export const WarningMsg = styled.span`
+  margin-top: 10px;
+  color: ${(props) => props.theme.errorColor};
+  font-weight: 500;
+`;
+
+const StyledFileDrop = styled.div<Pick<FileUploadState, 'dragOver'>>`
+  background-color: white;
+  border-radius: 4px;
+  border-style: ${(props) => (props.dragOver ? 'solid' : 'dashed')};
+  border-width: 1px;
+  border-color: ${(props) => (props.dragOver ? props.theme.textColorLT : props.theme.subtextColorLT)};
+  text-align: center;
+  width: 100%;
+  padding: 48px 8px 0;
+  height: 360px;
+
+  .file-upload-or {
+    color: ${(props) => props.theme.linkBtnColor};
+    padding-right: 4px;
+  }
+
+  .file-type-row {
+    opacity: 0.5;
+  }
+  ${media.portable`
+    padding: 16px 4px 0;
+  `};
+`;
+
+const MsgWrapper = styled.div`
+  color: ${(props) => props.theme.modalTitleColor};
+  font-size: 20px;
+  height: 36px;
+`;
+
+const StyledDragNDropIcon = styled.div`
+  color: ${fileIconColor};
+  margin-bottom: 48px;
+
+  ${media.portable`
+    margin-bottom: 16px;
+  `};
+  ${media.palm`
+    margin-bottom: 8px;
+  `};
+`;
+
+const StyledFileTypeFow = styled.div`
+  margin-bottom: 24px;
+  ${media.portable`
+    margin-bottom: 16px;
+  `};
+  ${media.palm`
+    margin-bottom: 8px;
+  `};
+`;
+
+const StyledFileUpload = styled.div`
+  .file-drop {
+    position: relative;
+  }
+`;
+
+const StyledMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 32px;
+
+  .loading-action {
+    margin-right: 10px;
+  }
+  .loading-spinner {
+    margin-left: 10px;
+  }
+`;
+
+const StyledDragFileWrapper = styled.div`
+  margin-bottom: 32px;
+  ${media.portable`
+    margin-bottom: 24px;
+  `};
+  ${media.portable`
+    margin-bottom: 16px;
+  `};
+`;
+
+const StyledDisclaimer = styled(StyledMessage)`
+  margin: 0 auto;
+`;
+
+interface FileUploadState {
+  dragOver: boolean;
+  fileLoading: boolean;
+  files: File[];
+  errorFiles: string[];
+}
+
+interface FileUploadProps {
+  fileLoading: boolean;
+  fileLoadingProgress: number;
+  fileExtensions?: string[];
+  disableExtensionFilter?: boolean;
+  fileFormatNames: string[];
+  onFileUpload: visStateActions['loadFiles'];
+  theme: DatatlasTheme;
+}
+
+function FileUploadFactory() {
+  return ({
+    fileLoading,
+    fileLoadingProgress,
+    fileExtensions = [],
+    disableExtensionFilter = false,
+    onFileUpload,
+    theme,
+  }: FileUploadProps) => {
+    const intl = useIntl();
+    const [state, setState] = useState<FileUploadState>({
+      dragOver: false,
+      fileLoading: false,
+      files: [],
+      errorFiles: [],
+    });
+
+    // @todo We should overwrite the ModalFactory and inject `fileFormatNames` there instead.
+    const { id } = useParams();
+    const fileFormatNames = useSelector((state: RootState) => selectFileFormatNamesByInstanceId(state, id));
+
+    const frame = createRef<HTMLDivElement>();
+
+    const _isValidFileType = (filename) => {
+      const fileExt = fileExtensions.find((ext) => filename.endsWith(ext));
+
+      return Boolean(fileExt);
+    };
+
+    const _handleFileInput = (fileList: FileList, event) => {
+      if (event) {
+        event.stopPropagation();
+      }
+
+      // @ts-ignore target is es2015 so it's allowed
+      const files: File[] = [...fileList].filter(Boolean);
+
+      // TODO - move this code out of the component
+      const filesToLoad: File[] = [];
+      const errorFiles: string[] = [];
+      for (const file of files) {
+        if (disableExtensionFilter || _isValidFileType(file.name)) {
+          filesToLoad.push(file);
+        } else {
+          errorFiles.push(file.name);
+        }
+      }
+
+      setState({ ...state, files: filesToLoad, errorFiles, dragOver: false });
+    };
+
+    useEffect(() => {
+      if (state.fileLoading && !fileLoading && state.files.length) {
+        setState({ ...state, files: [], fileLoading: fileLoading });
+      }
+      setState({ ...state, fileLoading: fileLoading });
+    }, [state.files.length, fileLoading]);
+
+    useEffect(() => {
+      if (state.files.length > 0) {
+        onFileUpload(state.files);
+      }
+    }, [state.files.length]);
+
+    const _toggleDragState = (dragOver: boolean) => {
+      setState({ ...state, dragOver });
+    };
+
+    const { dragOver, files, errorFiles } = state;
+    return (
+      <StyledFileUpload className="file-uploader" ref={frame}>
+        {FileDrop ? (
+          <FileDrop
+            frame={frame.current || document}
+            onDragOver={() => _toggleDragState(true)}
+            onDragLeave={() => _toggleDragState(false)}
+            onDrop={_handleFileInput}
+            className="file-uploader__file-drop"
+          >
+            <StyledUploadMessage className="file-upload__message">
+              <ReactMarkdown
+                components={markdownComponents}
+                children={intl.formatMessage(
+                  {
+                    id: 'fileUploader.configUploadMessage',
+                  },
+                  {
+                    fileFormatNames: fileFormatNames.map((format) => `**${format}**`).join(', '),
+                    fileFormatDocLink: GUIDES_FILE_FORMAT_DOC,
+                    contactEmail: process.env.REACT_APP_CONTACT_EMAIL,
+                  }
+                )}
+                linkTarget="_blank"
+              />
+            </StyledUploadMessage>
+            <StyledFileDrop dragOver={dragOver}>
+              <StyledFileTypeFow className="file-type-row">
+                {fileExtensions.map((ext) => (
+                  <FileType key={ext} ext={ext} height="50px" fontSize="9px" />
+                ))}
+              </StyledFileTypeFow>
+              {fileLoading ? (
+                <FileUploadProgress fileLoadingProgress={fileLoadingProgress} theme={theme} />
+              ) : (
+                <>
+                  <div style={{ opacity: dragOver ? 0.5 : 1 }} className="file-upload-display-message">
+                    <StyledDragNDropIcon>
+                      <DragNDrop height="44px" />
+                    </StyledDragNDropIcon>
+
+                    {errorFiles.length ? (
+                      <WarningMsg>
+                        <FormattedMessage
+                          id={'fileUploader.fileNotSupported'}
+                          values={{ errorFiles: errorFiles.join(', ') }}
+                        />
+                      </WarningMsg>
+                    ) : null}
+                  </div>
+                  {!files.length ? (
+                    <StyledDragFileWrapper>
+                      <MsgWrapper>
+                        <FormattedMessage id={'fileUploader.message'} />
+                      </MsgWrapper>
+                      <span className="file-upload-or">
+                        <FormattedMessage id={'fileUploader.or'} />
+                      </span>
+                      <UploadButton onUpload={_handleFileInput}>
+                        <FormattedMessage id={'fileUploader.browseFiles'} />
+                      </UploadButton>
+                    </StyledDragFileWrapper>
+                  ) : null}
+
+                  <StyledDisclaimer>
+                    <FormattedMessage id={'fileUploader.disclaimer'} />
+                  </StyledDisclaimer>
+                </>
+              )}
+            </StyledFileDrop>
+          </FileDrop>
+        ) : null}
+
+        <WarningMsg>{isChrome() ? <FormattedMessage id={'fileUploader.chromeMessage'} /> : ''}</WarningMsg>
+      </StyledFileUpload>
+    );
+  };
+}
+
+export function replaceFileUpload() {
+  return [KeplerFileUploadFactory, FileUploadFactory];
+}

--- a/apps/frontend/src/components/keplerGl/factories/common/file-upload/index.ts
+++ b/apps/frontend/src/components/keplerGl/factories/common/file-upload/index.ts
@@ -1,0 +1,1 @@
+export * from './FileUploadFactory';

--- a/apps/frontend/src/components/keplerGl/factories/common/index.ts
+++ b/apps/frontend/src/components/keplerGl/factories/common/index.ts
@@ -1,0 +1,1 @@
+export * from './file-upload';

--- a/apps/frontend/src/components/keplerGl/factories/index.ts
+++ b/apps/frontend/src/components/keplerGl/factories/index.ts
@@ -1,3 +1,4 @@
+export * from './common';
 export * from './filter-panel';
 export * from './map-control-panel';
 export * from './side-panel';

--- a/apps/frontend/src/components/keplerGl/injector.ts
+++ b/apps/frontend/src/components/keplerGl/injector.ts
@@ -1,6 +1,7 @@
 import { appInjector as keplerAppInjector } from 'kepler.gl';
 import { provideRecipesToInjector } from 'kepler.gl/dist/components';
 import {
+  replaceFileUpload,
   replaceLoadDataModal,
   replaceLayerManager,
   replaceLayerPanelHeader,
@@ -32,6 +33,7 @@ export const appInjector = provideRecipesToInjector(
     replacePanelTab(),
     replaceLayerManager(),
     replaceLoadDataModal(),
+    replaceFileUpload(),
     replaceLayerPanel(),
     replaceLayerPanelHeader(),
     replaceMapControl(),

--- a/apps/frontend/src/components/map-menu/MapMenu.tsx
+++ b/apps/frontend/src/components/map-menu/MapMenu.tsx
@@ -112,9 +112,10 @@ export const MapMenu = styled(
   .map-menu__header span,
   ${MultiSelectFilterOption}, .dataset-menu__show-dataset span,
   .dataset-menu__dataset-infos span {
+    font-family: 'Roboto', Verdana, 'Helvetica Neue', Helvetica, sans-serif;
     text-transform: uppercase;
     letter-spacing: 1.5px;
-    font-size: 14px;
+    font-size: 15px;
     font-weight: 500;
   }
 

--- a/apps/frontend/src/components/map-menu/MultiSelectFillter.tsx
+++ b/apps/frontend/src/components/map-menu/MultiSelectFillter.tsx
@@ -3,18 +3,18 @@ import styled from 'styled-components';
 
 export const MultiSelectFilterOption = styled(({ backgroundRgb, selected, ...props }) => <li {...props} />)`
   cursor: pointer;
-  color: ${({ selected }) => `rgba(255, 255, 255, ${selected ? 1 : 0.55})`};
-  background-color: ${({ backgroundRgb }) => `rgba(${backgroundRgb}, 0.75)`};
+  color: ${({ selected }) => `rgba(255, 255, 255, ${selected ? 1 : 0.5})`};
+  background-color: ${({ backgroundRgb }) => `rgba(${backgroundRgb}, 0.60)`};
   transition: background, color 0.3s ease;
 
   :hover {
     color: ${({ selected }) => `rgba(255, 255, 255, ${selected ? 1 : 0.9})`};
-    background-color: ${({ backgroundRgb }) => `rgba(${backgroundRgb}, 0.85)`};
+    background-color: ${({ backgroundRgb }) => `rgba(${backgroundRgb}, 0.80)`};
   }
 
   :active {
     color: ${({ selected }) => `rgba(255, 255, 255, ${selected ? 1 : 0.8})`};
-    background-color: ${({ backgroundRgb }) => `rgba(${backgroundRgb}, 0.70)`};
+    background-color: ${({ backgroundRgb }) => `rgba(${backgroundRgb}, 0.90)`};
   }
 `;
 

--- a/apps/frontend/src/components/markdown.tsx
+++ b/apps/frontend/src/components/markdown.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export const Anchor = ({ node, children, ...props }) => {
+  // https://github.com/remarkjs/react-markdown/issues/12
+  try {
+    new URL(props.href ?? '');
+    // If we don't get an error, then it's an absolute URL.
+    props.target = '_blank';
+    props.rel = 'noopener noreferrer';
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
+
+  return <a {...props}>{children}</a>;
+};
+
+export const markdownComponents = {
+  a: Anchor,
+};

--- a/apps/frontend/src/i18n/messages/en.ts
+++ b/apps/frontend/src/i18n/messages/en.ts
@@ -7,8 +7,6 @@ export default {
   'createProjectForm.projectName': 'Name of the project',
   'createProjectForm.submit': 'Create',
   'createProjectForm.titleRequired': 'This field is required',
-  'loadRemoteData.incorrectURL': 'Incorrect URL',
-  'loadRemoteData.submit': 'Load',
   'loginForm.errors.loginRequired': 'This field is required',
   'loginForm.errors.passwordRequired': 'This field is required',
   'loginForm.forgotPassword': 'I forgot my password',
@@ -22,10 +20,6 @@ export default {
   'project.contributors': 'Contributors',
   'project.projectUpdated': 'Updated at',
   'sideBar.createProject': 'Start new project:',
-  'layerManager.fileFormat':
-    'You can use the following formats: CSV / JSON / ... check that the url contains the extension of the\n file.',
-  'layerManager.contactUs': 'The desired format is not available {link}',
-  'layerManager.contactUs.link': 'Contact us',
   'layerManager.dataWeight': 'Too many datasets can corrupt the project',
   'filterManager.filter.make_public.label': 'Make this filter public',
   'filterManager.filter.make_public.tooltip': 'Show filter to visitors',
@@ -34,9 +28,28 @@ export default {
   'map_menu.dataset.show_dataset': 'Show dataset',
   'map_control.publish': 'Publish',
   'map_control.unpublish': 'Unpublish',
+  loadRemoteData: {
+    incorrectURL: 'Incorrect URL',
+    submit: 'Load',
+    description:
+      'You may import datasets from **[data.grandlyon.com](https://data.grandlyon.com/)**.\n\n' +
+      'Accepted file formats are : {fileFormatNames}... Be sure the file extension appears in the URL.\n\n' +
+      "If desired format isn't available, [contact us](mailto:{contactEmail}).\n\n",
+  },
 
   // Kepler
   'sidebar.panels.layer': 'Data',
   'sidebar.panels.filter': 'Filter',
   'sidebar.panels.interaction': 'Interface',
+  fileUploader: {
+    disclaimer: ' ',
+    configUploadMessage:
+      'You may upload files of the following formats {fileFormatNames}. \n\n' +
+      "If the desired format isn't available, [**contactez us**](mailto:{contactEmail}). \n\n" +
+      '*You may as well consult **Kepler.gl** documentation on [**accepted file formats**]({fileFormatDocLink}).*',
+    browseFiles: 'parcourir vos fichiers',
+    uploading: 'Téléchargement en cours',
+    fileNotSupported: "Le fichier {errorFiles} n'est pas pris en charge.",
+    or: 'ou',
+  },
 };

--- a/apps/frontend/src/i18n/messages/fr.ts
+++ b/apps/frontend/src/i18n/messages/fr.ts
@@ -9,8 +9,6 @@ export default {
   'createProjectForm.projectName': 'Entrez le nom du projet',
   'createProjectForm.submit': 'Créer',
   'createProjectForm.titleRequired': 'Ce champs est requis',
-  'loadRemoteData.incorrectURL': "L'URL n'est pas valide",
-  'loadRemoteData.submit': 'Charger',
   'loginForm.errors.loginRequired': 'Ce champs est requis',
   'loginForm.errors.passwordRequired': 'Ce champs est requis',
   'loginForm.forgotPassword': 'J’ai oublié mon mot de passe',
@@ -25,10 +23,6 @@ export default {
   'project.contributors': 'Contributeurs',
   'project.projectUpdated': 'Projet modifié',
   'sideBar.createProject': 'Démarrer un nouveau projet',
-  'layerManager.fileFormat':
-    "Vous pouvez utiliser les formats suivants : CSV / JSON / ... Assurez-vous que l'url contient l'extension du\n fichier.",
-  'layerManager.contactUs': 'Le format souhaité n’est pas disponible {link}',
-  'layerManager.contactUs.link': 'Contactez-nous',
   'layerManager.dataWeight': 'Un trop grand nombre de jeux de données peut altérer le projet',
   'filterManager.filter.make_public.label': 'Rendre ce filtre public',
   'filterManager.filter.make_public.tooltip': 'Affiche ce filtre aux visiteurs',
@@ -37,6 +31,14 @@ export default {
   'map_menu.dataset.show_dataset': 'Afficher le jeu de données',
   'map_control.publish': 'Publier',
   'map_control.unpublish': 'Dépublier',
+  loadRemoteData: {
+    incorrectURL: "L'URL n'est pas valide",
+    submit: 'Charger',
+    description:
+      'Vous pouvez importer des jeux de données par lien depuis **[data.grandlyon.com](https://data.grandlyon.com/)**.\n\n' +
+      "Vous pouvez utiliser les formats suivants : {fileFormatNames}... Assurez-vous que l'URL contient l'extension du fichier.\n\n" +
+      "Si le format souhaité n'est pas disponible, [contactez nous](mailto:{contactEmail}).\n\n",
+  },
 
   // Kepler
   sidebar: {
@@ -257,110 +259,113 @@ export default {
     deleteData: {
       warning: 'vous allez supprimer ce jeu de données. Cela affectera {length} couches',
     },
-    publishTitle:
-      "2. Si vous avez entré une URL de style Mapbox à l'étape 1, publiez votre style sur Mapbox ou fournissez un jeton d'accès. (Optionnel)",
-    publishSubtitle1: 'Vous pouvez créer votre propre style de carte sur',
-    publishSubtitle2: 'et le',
-    publishSubtitle3: 'publier',
-    publishSubtitle4: '.',
-    publishSubtitle5: 'Pour utiliser un style privé, collez votre',
-    publishSubtitle6: "jeton d'accès",
-    publishSubtitle7: 'ici. *kepler.gl est une application côté client, les données restent dans votre navigateur.',
-    exampleToken: 'e.g. pk.abcdefg.xxxxxx',
-    pasteTitle: "1. Collez l'URL du style",
-    pasteSubtitle0: "L'URL du style peut être une carte",
-    pasteSubtitle1: "Qu'est-ce qu'une",
-    pasteSubtitle2: 'URL de style',
-    pasteSubtitle3: 'ou un style.json utilisant le',
-    pasteSubtitle4: 'Mapbox GL Style Spec',
-    namingTitle: '3. Nommez votre style',
-  },
-  shareMap: {
-    shareUriTitle: "Partager l'URL de la carte",
-    shareUriSubtitle: "Générer une URL de la carte à partager avec d'autres personnes",
-    cloudTitle: 'Stockage Cloud',
-    cloudSubtitle: 'Connectez-vous et téléchargez les données de la carte dans votre stockage cloud personnel',
-    shareDisclaimer:
-      "kepler.gl enregistrera vos données de carte dans votre stockage cloud personnel. Seules les personnes disposant de l'URL peuvent accéder à votre carte et à vos données. " +
-      'Vous pouvez modifier/supprimer le fichier de données dans votre compte cloud à tout moment.',
-    gotoPage: 'Accédez à votre page Kepler.gl {currentProvider}',
-  },
-  statusPanel: {
-    mapUploading: 'Téléchargement de la carte',
-    error: 'Erreur',
-  },
-  saveMap: {
-    title: 'Stockage Cloud',
-    subtitle: 'Connectez-vous pour enregistrer la carte dans votre stockage cloud personnel',
-  },
-  exportMap: {
-    formatTitle: 'Format de la carte',
-    formatSubtitle: 'Choisissez le format vers lequel vous souhaitez exporter votre carte',
-    html: {
-      selection: 'Exportez votre carte dans un fichier HTML interactif.',
-      tokenTitle: "Jeton d'accès Mapbox",
-      tokenSubtitle: "Utilisez votre propre jeton d'accès Mapbox dans l'HTML (facultatif)",
-      tokenPlaceholder: "Collez votre jeton d'accès Mapbox",
-      tokenMisuseWarning:
-        "* Si vous ne fournissez pas votre propre jeton, la carte peut cesser de s'afficher à tout moment lorsque nous remplaçons le nôtre afin d'éviter une utilisation abusive.",
-      tokenDisclaimer: 'Vous pouvez modifier le jeton Mapbox plus tard en suivant les instructions suivantes :',
-      tokenUpdate: 'Comment mettre à jour un jeton de carte existant.',
-      modeTitle: 'Mode de la carte',
-      modeSubtitle1: "Sélectionnez le mode d'application. Plus ",
-      modeSubtitle2: 'informations',
-      modeDescription: 'Permettre aux utilisateurs de {mode} la carte',
-      read: 'lire',
-      edit: 'éditer',
+    addStyle: {
+      publishTitle:
+        "2. Si vous avez entré une URL de style Mapbox à l'étape 1, publiez votre style sur Mapbox ou fournissez un jeton d'accès. (Optionnel)",
+      publishSubtitle1: 'Vous pouvez créer votre propre style de carte sur',
+      publishSubtitle2: 'et le',
+      publishSubtitle3: 'publier',
+      publishSubtitle4: '.',
+      publishSubtitle5: 'Pour utiliser un style privé, collez votre',
+      publishSubtitle6: "jeton d'accès",
+      publishSubtitle7: 'ici. *kepler.gl est une application côté client, les données restent dans votre navigateur.',
+      exampleToken: 'e.g. pk.abcdefg.xxxxxx',
+      pasteTitle: "1. Collez l'URL du style",
+      pasteSubtitle0: "L'URL du style peut être une carte",
+      pasteSubtitle1: "Qu'est-ce qu'une",
+      pasteSubtitle2: 'URL de style',
+      pasteSubtitle3: 'ou un style.json utilisant le',
+      pasteSubtitle4: 'Mapbox GL Style Spec',
+      namingTitle: '3. Nommez votre style',
     },
-    json: {
-      configTitle: 'Configuration de la carte',
-      configDisclaimer:
-        'La configuration de la carte sera incluse dans le fichier Json. Si vous utilisez kepler.gl dans votre propre application, vous pouvez copier cette configuration et la passer à ',
-      selection:
-        'Exportez les données et la configuration de la carte actuelle dans un seul fichier Json. Vous pouvez ensuite ouvrir la même carte en téléchargeant ce fichier sur kepler.gl.',
-      disclaimer:
-        "* La configuration de la carte est couplée aux jeux de données chargés. L'identifiant de données est utilisé pour lier les couches, les filtres et les info-bulles à un jeu de données spécifique. " +
-        "Lorsque vous passez cette configuration à addDataToMap, assurez-vous que l'identifiant de données correspond aux identifiants de données dans cette configuration.",
+    shareMap: {
+      shareUriTitle: "Partager l'URL de la carte",
+      shareUriSubtitle: "Générer une URL de la carte à partager avec d'autres personnes",
+      cloudTitle: 'Stockage Cloud',
+      cloudSubtitle: 'Connectez-vous et téléchargez les données de la carte dans votre stockage cloud personnel',
+      shareDisclaimer:
+        "kepler.gl enregistrera vos données de carte dans votre stockage cloud personnel. Seules les personnes disposant de l'URL peuvent accéder à votre carte et à vos données. " +
+        'Vous pouvez modifier/supprimer le fichier de données dans votre compte cloud à tout moment.',
+      gotoPage: 'Accédez à votre page Kepler.gl {currentProvider}',
     },
-  },
-  loadingDialog: {
-    loading: 'Chargement en cours...',
-  },
-  loadData: {
-    upload: 'Charger des fichiers',
-    storage: 'Charger à partir du stockage',
-  },
-  tripInfo: {
-    title: "Comment activer l'animation de trajet",
-    description1:
-      'Pour animer le trajet, les données geoJSON doivent contenir `LineString` dans leur géométrie de fonctionnalité, et les coordonnées dans le LineString doivent avoir 4 éléments dans les formats de',
-    code: ' [longitude, latitude, altitude, horodatage] ',
-    description2:
-      "avec le dernier élément étant un horodatage. Les formats d'horodatage valides incluent unix en secondes tels que `1564184363` ou en millisecondes tels que `1564184363000`.",
-    example: 'Exemple:',
-  },
-  iconInfo: {
-    title: 'Comment dessiner des icônes',
-    description1:
-      "Dans votre csv, créez une colonne, mettez le nom de l'icône que vous voulez dessiner dedans. Vous pouvez laisser la cellule vide si vous ne voulez pas que l'icône apparaisse pour certains points. Lorsque la colonne est nommée",
-    code: 'icône',
-    description2: "kepler.gl créera automatiquement une couche d'icônes pour vous.",
-    example: 'Exemple:',
-    icons: 'Icônes',
-  },
-  storageMapViewer: {
-    lastModified: 'Dernière modification il y a {lastUpdated}',
-    back: 'Retour',
-  },
-  overwriteMap: {
-    title: 'Enregistrement de la carte en cours...',
-    alreadyExists: "existe déjà dans votre {mapSaved}. Voulez-vous l'écraser?",
-  },
-  loadStorageMap: {
-    back: 'Retour',
-    goToPage: 'Allez sur votre page Kepler.gl {displayName}',
-    storageMaps: 'Stockage / Cartes',
-    noSavedMaps: "Aucune carte enregistrée pour l'instant",
+    statusPanel: {
+      mapUploading: 'Téléchargement de la carte',
+      error: 'Erreur',
+    },
+    saveMap: {
+      title: 'Stockage Cloud',
+      subtitle: 'Connectez-vous pour enregistrer la carte dans votre stockage cloud personnel',
+    },
+    exportMap: {
+      formatTitle: 'Format de la carte',
+      formatSubtitle: 'Choisissez le format vers lequel vous souhaitez exporter votre carte',
+      html: {
+        selection: 'Exportez votre carte dans un fichier HTML interactif.',
+        tokenTitle: "Jeton d'accès Mapbox",
+        tokenSubtitle: "Utilisez votre propre jeton d'accès Mapbox dans l'HTML (facultatif)",
+        tokenPlaceholder: "Collez votre jeton d'accès Mapbox",
+        tokenMisuseWarning:
+          "* Si vous ne fournissez pas votre propre jeton, la carte peut cesser de s'afficher à tout moment lorsque nous remplaçons le nôtre afin d'éviter une utilisation abusive.",
+        tokenDisclaimer: 'Vous pouvez modifier le jeton Mapbox plus tard en suivant les instructions suivantes :',
+        tokenUpdate: 'Comment mettre à jour un jeton de carte existant.',
+        modeTitle: 'Mode de la carte',
+        modeSubtitle1: "Sélectionnez le mode d'application. Plus ",
+        modeSubtitle2: 'informations',
+        modeDescription: 'Permettre aux utilisateurs de {mode} la carte',
+        read: 'lire',
+        edit: 'éditer',
+      },
+      json: {
+        configTitle: 'Configuration de la carte',
+        configDisclaimer:
+          'La configuration de la carte sera incluse dans le fichier Json. Si vous utilisez kepler.gl dans votre propre application, vous pouvez copier cette configuration et la passer à ',
+        selection:
+          'Exportez les données et la configuration de la carte actuelle dans un seul fichier Json. Vous pouvez ensuite ouvrir la même carte en téléchargeant ce fichier sur kepler.gl.',
+        disclaimer:
+          "* La configuration de la carte est couplée aux jeux de données chargés. L'identifiant de données est utilisé pour lier les couches, les filtres et les info-bulles à un jeu de données spécifique. " +
+          "Lorsque vous passez cette configuration à addDataToMap, assurez-vous que l'identifiant de données correspond aux identifiants de données dans cette configuration.",
+      },
+      loadingDialog: {
+        loading: 'Chargement en cours...',
+      },
+    },
+    loadData: {
+      remote: 'Avec une URL',
+      upload: 'Avec un fichier',
+      storage: "A partir d'un stockage distant",
+    },
+    tripInfo: {
+      title: "Comment activer l'animation de trajet",
+      description1:
+        'Pour animer le trajet, les données geoJSON doivent contenir `LineString` dans leur géométrie de fonctionnalité, et les coordonnées dans le LineString doivent avoir 4 éléments dans les formats de',
+      code: ' [longitude, latitude, altitude, horodatage] ',
+      description2:
+        "avec le dernier élément étant un horodatage. Les formats d'horodatage valides incluent unix en secondes tels que `1564184363` ou en millisecondes tels que `1564184363000`.",
+      example: 'Exemple:',
+    },
+    iconInfo: {
+      title: 'Comment dessiner des icônes',
+      description1:
+        "Dans votre csv, créez une colonne, mettez le nom de l'icône que vous voulez dessiner dedans. Vous pouvez laisser la cellule vide si vous ne voulez pas que l'icône apparaisse pour certains points. Lorsque la colonne est nommée",
+      code: 'icône',
+      description2: "kepler.gl créera automatiquement une couche d'icônes pour vous.",
+      example: 'Exemple:',
+      icons: 'Icônes',
+    },
+    storageMapViewer: {
+      lastModified: 'Dernière modification il y a {lastUpdated}',
+      back: 'Retour',
+    },
+    overwriteMap: {
+      title: 'Enregistrement de la carte en cours...',
+      alreadyExists: "existe déjà dans votre {mapSaved}. Voulez-vous l'écraser?",
+    },
+    loadStorageMap: {
+      back: 'Retour',
+      goToPage: 'Allez sur votre page Kepler.gl {displayName}',
+      storageMaps: 'Stockage / Cartes',
+      noSavedMaps: "Aucune carte enregistrée pour l'instant",
+    },
   },
   header: {
     visibleLayers: 'Couches visibles',
@@ -420,11 +425,11 @@ export default {
     message: 'Glissez et déposez votre (vos) fichier(s) ici',
     chromeMessage:
       '* Utilisateur de Chrome : Limitez la taille du fichier à 250 Mo. Si vous devez télécharger un fichier plus volumineux, essayez Safari.',
-    disclaimer:
-      '*kepler.gl est une application côté client sans backend de serveur. Les données ne sont stockées que sur votre machine/navigateur. ' +
-      "Aucune information ou donnée de carte n'est envoyée à un serveur quelconque.",
+    disclaimer: ' ',
     configUploadMessage:
-      'Télécharger {fileFormatNames} ou sauvegardez la carte **Json**. En savoir plus sur [**formats de fichiers pris en charge**]',
+      'Télécharger un fichier au format {fileFormatNames}. \n\n' +
+      "Si le format souhaité n'est pas disponible, [**contactez nous**](mailto:{contactEmail}). \n\n" +
+      '*Vous pouvez également consulter la documentation **Kepler.gl** sur les [**formats de fichiers pris en charge**]({fileFormatDocLink}).*',
     browseFiles: 'parcourir vos fichiers',
     uploading: 'Téléchargement en cours',
     fileNotSupported: "Le fichier {errorFiles} n'est pas pris en charge.",

--- a/apps/frontend/src/store/selectors.ts
+++ b/apps/frontend/src/store/selectors.ts
@@ -6,14 +6,30 @@ import { RootState } from './reducers';
 import { getUser } from './api';
 import { projectFactory } from '../kepler';
 
-export const toKeplerId = (id: number) => String(id).toLocaleUpperCase();
+export const toKeplerId = (id: string | number) => String(id).toLocaleUpperCase();
 
-export const selectKeplerInstanceById = (state: RootState, instanceId: string) => state.keplerGl[instanceId];
+export const selectKeplerInstanceById = (state: RootState, instanceId?: string | number) =>
+  instanceId ? state.keplerGl[instanceId] : {};
 export const isFileLoading = (state: RootState, instanceId: string) =>
   selectKeplerInstanceById(state, instanceId).visState.fileLoading;
 export const selectMapInfoFromKeplerGlState = (state: KeplerGlState) => {
   return state.visState?.mapInfo as MapInfoInterface;
 };
+
+const DEFAULT_FILE_EXTENSIONS = ['csv', 'geojson'];
+const DEFAULT_FILE_FORMATS = ['CSV', 'GeoJSON'];
+
+export const selectFileFormatNames = createSelector(
+  (state: KeplerGlState) => state.loaders || [],
+  (loaders) => [...DEFAULT_FILE_FORMATS, ...loaders.map((loader) => loader.name)]
+);
+
+export const selectFileExtensions = createSelector(
+  (state: KeplerGlState) => state.loaders,
+  (loaders) => [...DEFAULT_FILE_EXTENSIONS, ...loaders.flatMap((loader) => loader.extensions)]
+);
+
+export const selectFileFormatNamesByInstanceId = createSelector(selectKeplerInstanceById, selectFileFormatNames);
 
 export const selectFilters = (state: RootState, instanceId: string): Filter[] =>
   selectKeplerInstanceById(state, instanceId).visState.filters;

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "strictPropertyInitialization": false,
 
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "react-hook-form": "^7.42.1",
         "react-intl": "^3.12.1",
         "react-is": "18.2.0",
+        "react-markdown": "^8.0.7",
         "react-palm": "^3.3.8",
         "react-router": "^6.6.2",
         "react-router-dom": "6.4.3",
@@ -142,7 +143,7 @@
         "whatwg-fetch": "^3.6.2"
       },
       "engines": {
-        "node": ">=16 <17"
+        "node": ">=16 <=18"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -18024,6 +18025,27 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/decode-named-character-reference/node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -18224,6 +18246,14 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -21723,6 +21753,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hastscript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
@@ -21921,13 +21960,16 @@
       }
     },
     "node_modules/html-to-react": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.5.0.tgz",
-      "integrity": "sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.6.0.tgz",
+      "integrity": "sha512-W7HvCu2fipgz3F7fpEtIt2Ty6XcqFGQXOorR4+HQAk72y9mTtUH3BmJ43BEvXQHO+bt//z1Hbfe6JzojpSC/9w==",
       "dependencies": {
         "domhandler": "^5.0",
         "htmlparser2": "^8.0",
         "lodash.camelcase": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "^0.13.0 || ^0.14.0 || >=15"
       }
     },
     "node_modules/html-void-elements": {
@@ -29351,6 +29393,41 @@
         "node": ">=10"
       }
     },
+    "node_modules/kepler.gl/node_modules/mdast-util-from-markdown": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/kepler.gl/node_modules/micromark": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.0.0",
+        "parse-entities": "^2.0.0"
+      }
+    },
     "node_modules/kepler.gl/node_modules/performance-now": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
@@ -29364,6 +29441,11 @@
         "lodash": "^4.17.20",
         "renderkid": "^2.0.4"
       }
+    },
+    "node_modules/kepler.gl/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/kepler.gl/node_modules/react-map-gl-draw": {
       "version": "0.14.8",
@@ -29381,6 +29463,31 @@
         "react": "0.14.x - 16.x",
         "react-dom": "0.14.x - 16.x",
         "react-map-gl": ">=4.0.0"
+      }
+    },
+    "node_modules/kepler.gl/node_modules/react-markdown": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
+      "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
+      "dependencies": {
+        "@types/mdast": "^3.0.3",
+        "@types/unist": "^2.0.3",
+        "html-to-react": "^1.3.4",
+        "mdast-add-list-metadata": "1.0.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "remark-parse": "^9.0.0",
+        "unified": "^9.0.0",
+        "unist-util-visit": "^2.0.0",
+        "xtend": "^4.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
       }
     },
     "node_modules/kepler.gl/node_modules/react-vis": {
@@ -29455,6 +29562,18 @@
       },
       "peerDependencies": {
         "react": "^0.14.9 || ^15.3.0 || ^16.0.0"
+      }
+    },
+    "node_modules/kepler.gl/node_modules/remark-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "dependencies": {
+        "mdast-util-from-markdown": "^0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/kepler.gl/node_modules/renderkid": {
@@ -30604,15 +30723,46 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "micromark": "~2.11.0",
-        "parse-entities": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown/node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -30766,9 +30916,9 @@
       }
     },
     "node_modules/micromark": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -30780,9 +30930,411 @@
         }
       ],
       "dependencies": {
+        "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
-        "parse-entities": "^2.0.0"
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
       }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -31038,6 +31590,14 @@
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
       "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
       "peer": true
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/mrmime": {
       "version": "1.0.1",
@@ -35103,20 +35663,25 @@
       }
     },
     "node_modules/react-markdown": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
-      "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+      "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
       "dependencies": {
-        "@types/mdast": "^3.0.3",
-        "@types/unist": "^2.0.3",
-        "html-to-react": "^1.3.4",
-        "mdast-add-list-metadata": "1.0.1",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.6",
-        "remark-parse": "^9.0.0",
-        "unified": "^9.0.0",
-        "unist-util-visit": "^2.0.0",
-        "xtend": "^4.0.1"
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.4.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -35127,10 +35692,188 @@
         "react": ">=16"
       }
     },
-    "node_modules/react-markdown/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    "node_modules/react-markdown/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react-markdown/node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react-markdown/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/react-markdown/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-markdown/node_modules/property-information": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
+      "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react-markdown/node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react-markdown/node_modules/style-to-object": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
+      "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
+      }
+    },
+    "node_modules/react-markdown/node_modules/trough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/react-markdown/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-markdown/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-markdown/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-markdown/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-markdown/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-markdown/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-markdown/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/react-modal": {
       "version": "3.16.1",
@@ -38644,11 +39387,339 @@
       }
     },
     "node_modules/remark-parse": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+      "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
       "dependencies": {
-        "mdast-util-from-markdown": "^0.8.0"
+        "@types/mdast": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-parse/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/remark-parse/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-parse/node_modules/trough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-parse/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-hast": "^12.1.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/mdast-util-definitions": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+      "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/mdast-util-to-hast": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+      "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-definitions": "^5.0.0",
+        "micromark-util-sanitize-uri": "^1.1.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-generated": "^2.0.0",
+        "unist-util-position": "^4.0.0",
+        "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/trough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unist-util-generated": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unist-util-position": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
+      "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unist-util-visit": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+      "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.1.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unist-util-visit-parents": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+      "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -39277,6 +40348,17 @@
       "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safe-buffer": {
@@ -41491,6 +42573,15 @@
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ=="
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -42860,6 +43951,39 @@
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/uvu/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/uvu/node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -58009,6 +59133,21 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
+    "decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "requires": {
+        "character-entities": "^2.0.0"
+      },
+      "dependencies": {
+        "character-entities": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+          "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+        }
+      }
+    },
     "decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -58162,6 +59301,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "destroy": {
       "version": "1.2.0",
@@ -60856,6 +62000,11 @@
         "zwitch": "^1.0.0"
       }
     },
+    "hast-util-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
+      "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng=="
+    },
     "hastscript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
@@ -61016,9 +62165,9 @@
       "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg=="
     },
     "html-to-react": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.5.0.tgz",
-      "integrity": "sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.6.0.tgz",
+      "integrity": "sha512-W7HvCu2fipgz3F7fpEtIt2Ty6XcqFGQXOorR4+HQAk72y9mTtUH3BmJ43BEvXQHO+bt//z1Hbfe6JzojpSC/9w==",
       "requires": {
         "domhandler": "^5.0",
         "htmlparser2": "^8.0",
@@ -66676,6 +67825,27 @@
             "yallist": "^4.0.0"
           }
         },
+        "mdast-util-from-markdown": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+          "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "mdast-util-to-string": "^2.0.0",
+            "micromark": "~2.11.0",
+            "parse-entities": "^2.0.0",
+            "unist-util-stringify-position": "^2.0.0"
+          }
+        },
+        "micromark": {
+          "version": "2.11.4",
+          "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+          "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+          "requires": {
+            "debug": "^4.0.0",
+            "parse-entities": "^2.0.0"
+          }
+        },
         "performance-now": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
@@ -66690,6 +67860,11 @@
             "renderkid": "^2.0.4"
           }
         },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
         "react-map-gl-draw": {
           "version": "0.14.8",
           "resolved": "https://registry.npmjs.org/react-map-gl-draw/-/react-map-gl-draw-0.14.8.tgz",
@@ -66701,6 +67876,23 @@
             "prop-types": "^15.5.7",
             "uuid": "^3.3.2",
             "viewport-mercator-project": ">=5.0.0"
+          }
+        },
+        "react-markdown": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
+          "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
+          "requires": {
+            "@types/mdast": "^3.0.3",
+            "@types/unist": "^2.0.3",
+            "html-to-react": "^1.3.4",
+            "mdast-add-list-metadata": "1.0.1",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.6",
+            "remark-parse": "^9.0.0",
+            "unified": "^9.0.0",
+            "unist-util-visit": "^2.0.0",
+            "xtend": "^4.0.1"
           }
         },
         "react-vis": {
@@ -66767,6 +67959,14 @@
                 "raf": "^3.1.0"
               }
             }
+          }
+        },
+        "remark-parse": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+          "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+          "requires": {
+            "mdast-util-from-markdown": "^0.8.0"
           }
         },
         "renderkid": {
@@ -67635,15 +68835,40 @@
       }
     },
     "mdast-util-from-markdown": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
       "requires": {
         "@types/mdast": "^3.0.0",
-        "mdast-util-to-string": "^2.0.0",
-        "micromark": "~2.11.0",
-        "parse-entities": "^2.0.0",
-        "unist-util-stringify-position": "^2.0.0"
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "dependencies": {
+        "mdast-util-to-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+          "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+          "requires": {
+            "@types/mdast": "^3.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        }
       }
     },
     "mdast-util-to-hast": {
@@ -67760,13 +68985,215 @@
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
     },
     "micromark": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
       "requires": {
+        "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
-        "parse-entities": "^2.0.0"
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
       }
+    },
+    "micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "requires": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw=="
+    },
+    "micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q=="
+    },
+    "micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "requires": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag=="
+    },
+    "micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg=="
     },
     "micromatch": {
       "version": "4.0.5",
@@ -67948,6 +69375,11 @@
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
       "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
       "peer": true
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
     },
     "mrmime": {
       "version": "1.0.1",
@@ -70756,26 +72188,138 @@
       }
     },
     "react-markdown": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-5.0.3.tgz",
-      "integrity": "sha512-jDWOc1AvWn0WahpjW6NK64mtx6cwjM4iSsLHJPNBqoAgGOVoIdJMqaKX4++plhOtdd4JksdqzlDibgPx6B/M2w==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.7.tgz",
+      "integrity": "sha512-bvWbzG4MtOU62XqBx3Xx+zB2raaFFsq4mYiAzfjXJMEz2sixgeAfraA3tvzULF02ZdOMUOKTBFFaZJDDrq+BJQ==",
       "requires": {
-        "@types/mdast": "^3.0.3",
-        "@types/unist": "^2.0.3",
-        "html-to-react": "^1.3.4",
-        "mdast-add-list-metadata": "1.0.1",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.6",
-        "remark-parse": "^9.0.0",
-        "unified": "^9.0.0",
-        "unist-util-visit": "^2.0.0",
-        "xtend": "^4.0.1"
+        "@types/hast": "^2.0.0",
+        "@types/prop-types": "^15.0.0",
+        "@types/unist": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "prop-types": "^15.0.0",
+        "property-information": "^6.0.0",
+        "react-is": "^18.0.0",
+        "remark-parse": "^10.0.0",
+        "remark-rehype": "^10.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-object": "^0.4.0",
+        "unified": "^10.0.0",
+        "unist-util-visit": "^4.0.0",
+        "vfile": "^5.0.0"
       },
       "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "comma-separated-tokens": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+          "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "property-information": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
+          "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg=="
+        },
+        "space-separated-tokens": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+          "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+        },
+        "style-to-object": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.4.1.tgz",
+          "integrity": "sha512-HFpbb5gr2ypci7Qw+IOhnP2zOU7e77b+rzM+wTzXzfi1PrtBCX0E7Pk4wL4iTLnhzZ+JgEGAhX81ebTg/aYjQw==",
+          "requires": {
+            "inline-style-parser": "0.1.1"
+          }
+        },
+        "trough": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+          "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+        },
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.1.1"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
         }
       }
     },
@@ -73399,11 +74943,217 @@
       }
     },
     "remark-parse": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-      "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+      "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
       "requires": {
-        "mdast-util-from-markdown": "^0.8.0"
+        "@types/mdast": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "trough": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+          "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+        },
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
+        }
+      }
+    },
+    "remark-rehype": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
+      "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-hast": "^12.1.0",
+        "unified": "^10.0.0"
+      },
+      "dependencies": {
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
+        "mdast-util-definitions": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
+          "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+          "requires": {
+            "@types/mdast": "^3.0.0",
+            "@types/unist": "^2.0.0",
+            "unist-util-visit": "^4.0.0"
+          }
+        },
+        "mdast-util-to-hast": {
+          "version": "12.3.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
+          "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+          "requires": {
+            "@types/hast": "^2.0.0",
+            "@types/mdast": "^3.0.0",
+            "mdast-util-definitions": "^5.0.0",
+            "micromark-util-sanitize-uri": "^1.1.0",
+            "trim-lines": "^3.0.0",
+            "unist-util-generated": "^2.0.0",
+            "unist-util-position": "^4.0.0",
+            "unist-util-visit": "^4.0.0"
+          }
+        },
+        "trough": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+          "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+        },
+        "unified": {
+          "version": "10.1.2",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+          "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "bail": "^2.0.0",
+            "extend": "^3.0.0",
+            "is-buffer": "^2.0.0",
+            "is-plain-obj": "^4.0.0",
+            "trough": "^2.0.0",
+            "vfile": "^5.0.0"
+          }
+        },
+        "unist-util-generated": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+          "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A=="
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-position": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
+          "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+          "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-visit": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
+          "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0",
+            "unist-util-visit-parents": "^5.1.1"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
+          "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.7",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+          "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+          "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
+          }
+        }
       }
     },
     "remark-squeeze-paragraphs": {
@@ -73874,6 +75624,14 @@
           "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
           "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg=="
         }
+      }
+    },
+    "sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "requires": {
+        "mri": "^1.1.0"
       }
     },
     "safe-buffer": {
@@ -75574,6 +77332,11 @@
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ=="
     },
+    "trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
+    },
     "trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -76500,6 +78263,29 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+    },
+    "uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "requires": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
+        },
+        "kleur": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+          "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
+        }
+      }
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "react-hook-form": "^7.42.1",
     "react-intl": "^3.12.1",
     "react-is": "18.2.0",
+    "react-markdown": "^8.0.7",
     "react-palm": "^3.3.8",
     "react-router": "^6.6.2",
     "react-router-dom": "6.4.3",


### PR DESCRIPTION
Allow markdown to be passed in these translations. 
Changes default data loaders (remove storage loader).
Allow contact email configuration via an env variable.

> Fix #208 