### PR TITLE
Draft projects musn't be publicly accessible

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ POSTGRES_PORT=5432
 ## SALT
 PASSWORD_SALT=put_long_string_here
 
+## SEEDING USERS (1 admin and 1 editor)
+ADMIN_EMAIL=admin@example.org
+ADMIN_PASSWORD=admin
+DUMMY_EDITOR_EMAIL=editor@example.org
+DUMMY_EDITOR_PASSWORD=editor
+
 # FRONTEND
 REACT_APP_MAPBOX_ACCESS_TOKEN="defaultMapboxToken"
 REACT_APP_CONTACT_EMAIL=me@example.org

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,5 @@ jobs:
       - run: npx nx format:check --base=$BASE_BRANCH
       - run: npx nx affected --target=lint --parallel=3 --base=origin/$BASE_BRANCH
       - run: npx nx affected --target=test --parallel=3 --ci --code-coverage --base=origin/$BASE_BRANCH
+      - run: npx nx affected --target=e2e --parallel=2 --ci --code-coverage --base=origin/$BASE_BRANCH
       - run: npx nx affected --target=build --parallel=3 --base=origin/$BASE_BRANCH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,27 @@ on:
 
 env:
   BASE_BRANCH: dev
+  POSTGRES_PASSWORD: postgres
+  ADMIN_EMAIL: admin@example.org
+  ADMIN_PASSWORD: admin
+  DUMMY_EDITOR_EMAIL: editor@example.org
+  DUMMY_EDITOR_PASSWORD: editor
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,5 +43,8 @@ jobs:
       - run: npx nx format:check --base=$BASE_BRANCH
       - run: npx nx affected --target=lint --parallel=3 --base=origin/$BASE_BRANCH
       - run: npx nx affected --target=test --parallel=3 --ci --code-coverage --base=origin/$BASE_BRANCH
-      - run: npx nx affected --target=e2e --parallel=2 --ci --code-coverage --base=origin/$BASE_BRANCH
+      - run: |
+          npx nx serve backend &
+          npx wait-on http://localhost:3333/api
+      - run: npx nx e2e backend-e2e
       - run: npx nx affected --target=build --parallel=3 --base=origin/$BASE_BRANCH

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log
 testem.log
 /typings
 .env
+cypress.log
 
 # System Files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ npx nx run backend-e2e:e2e --spec apps/backend-e2e/src/e2e/user.cy.ts
 
 https://github.com/cypress-io/cypress/issues/2610#issuecomment-1319738814
 
+Output test results to a log file:
+
+```
+npx nx run backend-e2e:e2e --spec apps/backend-e2e/src/e2e/user.cy.ts &> cypress.log
+```
+
 #### Cypress
 
 https://github.com/nrwl/nx/tree/master/packages/cypress/docs

--- a/apps/backend-e2e/cypress.config.ts
+++ b/apps/backend-e2e/cypress.config.ts
@@ -2,7 +2,26 @@ import { defineConfig } from 'cypress';
 import { nxE2EPreset } from '@nrwl/cypress/plugins/cypress-preset';
 
 export default defineConfig({
-  e2e: nxE2EPreset(__dirname),
+  e2e: {
+    ...nxE2EPreset(__dirname),
+    // setupNodeEvents can be defined in either
+    // the e2e or component configuration
+    setupNodeEvents(on, config) {
+      require('cypress-terminal-report/src/installLogsPrinter')(on);
+    },
+    video: false,
+  },
   video: false,
   screenshotOnRunFailure: false,
+
+  env: {
+    admin_credentials: {
+      email: process.env.ADMIN_EMAIL,
+      password: process.env.ADMIN_PASSWORD,
+    },
+    editor_credentials: {
+      email: process.env.DUMMY_EDITOR_USERNAME,
+      password: process.env.DUMMY_EDITOR_PASSWORD,
+    },
+  },
 });

--- a/apps/backend-e2e/cypress.config.ts
+++ b/apps/backend-e2e/cypress.config.ts
@@ -10,9 +10,8 @@ export default defineConfig({
       require('cypress-terminal-report/src/installLogsPrinter')(on);
     },
     video: false,
+    screenshotOnRunFailure: false,
   },
-  video: false,
-  screenshotOnRunFailure: false,
 
   env: {
     admin_credentials: {

--- a/apps/backend-e2e/cypress.config.ts
+++ b/apps/backend-e2e/cypress.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       password: process.env.ADMIN_PASSWORD,
     },
     editor_credentials: {
-      email: process.env.DUMMY_EDITOR_USERNAME,
+      email: process.env.DUMMY_EDITOR_EMAIL,
       password: process.env.DUMMY_EDITOR_PASSWORD,
     },
   },

--- a/apps/backend-e2e/src/e2e/auth.cy.ts
+++ b/apps/backend-e2e/src/e2e/auth.cy.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 
-describe('AUTHENTIFICATION TESTS', () => {
+describe('Authentication', () => {
   /*
       TESTS TO MAKE IN THIS ORDER
       - Connecting with incorrect user.
@@ -15,18 +15,45 @@ describe('AUTHENTIFICATION TESTS', () => {
       - Check self-profile of editor user with wrong jwt.
       - Check self-profile with correct jwt.
    */
-
-  /*
-      SENSIBLE DATA MUST BE SENT WITH COMMAND LINE AND OVERRIDE FOLLOWING DEFAULT ONES :
-   */
-  let jwtUser = {};
-  let idUserAdmin;
-  let idUserEditor;
-
-  /*
-      TESTS
-   */
-  it('Auth -> Connecting with incorrect user.', () => {
+  it('Should fail when trying to connect without any credentials 1/2.', () => {
+    cy.request({
+      method: 'POST',
+      url: '/api/auth/login',
+      body: {},
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401);
+    });
+  });
+  it('Should fail when trying to connect without any credentials 2/2.', () => {
+    cy.request({
+      method: 'GET',
+      url: '/api/auth/login',
+      body: {},
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(404);
+    });
+  });
+  it('Should fail when trying to connect without any data 1/2.', () => {
+    cy.request({
+      method: 'POST',
+      url: '/api/auth/login',
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(401);
+    });
+  });
+  it('Should fail when trying to connect without any data 2/2.', () => {
+    cy.request({
+      method: 'GET',
+      url: '/api/auth/login',
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status).to.eq(404);
+    });
+  });
+  it('Connecting with incorrect user.', () => {
     cy.request({
       method: 'POST',
       url: '/api/auth/login',
@@ -39,7 +66,7 @@ describe('AUTHENTIFICATION TESTS', () => {
       expect(response.status).to.eq(401);
     });
   });
-  it('Auth -> Connecting with proper user admin but wrong admin password.', () => {
+  it('Connecting with proper user admin but wrong admin password.', () => {
     cy.request({
       method: 'POST',
       url: '/api/auth/login',
@@ -52,7 +79,7 @@ describe('AUTHENTIFICATION TESTS', () => {
       expect(response.status).to.eq(401);
     });
   });
-  it('Auth -> Connecting correctly with admin user.', () => {
+  it('Connecting correctly with admin user.', () => {
     cy.request({
       method: 'POST',
       url: '/api/auth/login',
@@ -62,40 +89,13 @@ describe('AUTHENTIFICATION TESTS', () => {
       },
       failOnStatusCode: false,
     }).then((response) => {
-      jwtUser = response.body.access_token;
-      idUserAdmin = response.body.user_id;
       expect(response.status).to.eq(201);
     });
   });
-  it('Auth -> Check self-profile of admin user with wrong jwt.', () => {
-    cy.request({
-      method: 'GET',
-      url: `/api/users/${idUserAdmin}`,
-      failOnStatusCode: false,
-      auth: {
-        bearer: 'incorrect_jwt',
-      },
-    }).then((response) => {
-      expect(response.status).to.eq(403);
-    });
+  it('Login as admin.', () => {
+    cy.login(Cypress.env('admin_credentials'));
   });
-  it('Auth -> Check self-profile of admin user with correct jwt.', () => {
-    cy.request({
-      method: 'GET',
-      url: `/api/users/${idUserAdmin}`,
-      failOnStatusCode: false,
-      auth: {
-        bearer: jwtUser,
-      },
-    }).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.id).to.eq(idUserAdmin);
-      expect(response.body.role).to.eq('ADMIN');
-      expect(response.body.active).to.eq(true);
-      expect(response.body.email).to.eq('admin@example.org');
-    });
-  });
-  it('Auth -> Connecting with proper editor user but wrong password.', () => {
+  it('Connecting with proper editor user but wrong password.', () => {
     cy.request({
       method: 'POST',
       url: '/api/auth/login',
@@ -108,47 +108,7 @@ describe('AUTHENTIFICATION TESTS', () => {
       expect(response.status).to.eq(401);
     });
   });
-  it('Auth -> Connecting correctly with editor user.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        email: 'editor@example.org',
-        password: 'editor',
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(201);
-      jwtUser = response.body.access_token;
-      idUserEditor = response.body.user_id;
-    });
-  });
-  it('Auth -> Check self-profile of editor user with wrong jwt.', () => {
-    cy.request({
-      method: 'GET',
-      url: `/api/users/${idUserEditor}`,
-      failOnStatusCode: false,
-      auth: {
-        bearer: 'incorrect_jwt',
-      },
-    }).then((response) => {
-      expect(response.status).to.eq(403);
-    });
-  });
-  it('Auth -> Check self-profile of editor user with correct jwt.', () => {
-    cy.request({
-      method: 'GET',
-      url: `/api/users/${idUserEditor}`,
-      failOnStatusCode: false,
-      auth: {
-        bearer: jwtUser,
-      },
-    }).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.id).to.eq(idUserEditor);
-      expect(response.body.role).to.eq('EDITOR');
-      expect(response.body.active).to.eq(true);
-      expect(response.body.email).to.eq('editor');
-    });
+  it('Login as an editor', () => {
+    cy.login(Cypress.env('editor_credentials'));
   });
 });

--- a/apps/backend-e2e/src/e2e/auth.cy.ts
+++ b/apps/backend-e2e/src/e2e/auth.cy.ts
@@ -79,20 +79,7 @@ describe('Authentication', () => {
       expect(response.status).to.eq(401);
     });
   });
-  it('Connecting correctly with admin user.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        username: 'admin@example.org',
-        password: 'admin',
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(201);
-    });
-  });
-  it('Login as admin.', () => {
+  it('Login as admin', () => {
     cy.login(Cypress.env('admin_credentials'));
   });
   it('Connecting with proper editor user but wrong password.', () => {

--- a/apps/backend-e2e/src/e2e/auth.cy.ts
+++ b/apps/backend-e2e/src/e2e/auth.cy.ts
@@ -53,7 +53,7 @@ describe('Authentication', () => {
       expect(response.status).to.eq(404);
     });
   });
-  it('Connecting with incorrect user.', () => {
+  it('Should fail to connect with incorrect user.', () => {
     cy.request({
       method: 'POST',
       url: '/api/auth/login',
@@ -66,7 +66,7 @@ describe('Authentication', () => {
       expect(response.status).to.eq(401);
     });
   });
-  it('Connecting with proper user admin but wrong admin password.', () => {
+  it('Should fail to connect as an admin with incorrect password.', () => {
     cy.request({
       method: 'POST',
       url: '/api/auth/login',
@@ -82,7 +82,7 @@ describe('Authentication', () => {
   it('Login as admin', () => {
     cy.login(Cypress.env('admin_credentials'));
   });
-  it('Connecting with proper editor user but wrong password.', () => {
+  it('Should fail to connect as an editor with incorrect password.', () => {
     cy.request({
       method: 'POST',
       url: '/api/auth/login',

--- a/apps/backend-e2e/src/e2e/project.cy.ts
+++ b/apps/backend-e2e/src/e2e/project.cy.ts
@@ -1,10 +1,8 @@
-import type { CreateProjectDto, UpdateProjectDto } from '@datatlas/dtos';
-
 describe('PROJECT ACTIONS', () => {
   // DATA
   const fakeProject = {
     title: 'string',
-    draft: true,
+    draft: false,
     datasets: [],
     description: 'string',
     contributors: [],
@@ -558,6 +556,27 @@ describe('PROJECT ACTIONS', () => {
     }).then((response) => {
       expect(response.status).to.eq(200);
       expect(response.body).to.be.a('string');
+    });
+  });
+
+  describe('Requesting a draft project', () => {
+    it('should return an unauthorized code when not authenticated', () => {
+      cy.login(Cypress.env('admin_credentials')).then(() => {
+        cy.authenticatedRequest({
+          method: 'POST',
+          url: '/api/projects',
+          body: { ...fakeProject, draft: true },
+        }).then((response) => {
+          expect(response.status).to.eq(201);
+          expect(response.body.id).not.to.be.null;
+
+          cy.request({
+            method: 'GET',
+            url: `/api/projects/${response.body.id}`,
+            failOnStatusCode: false,
+          }).then((response) => expect(response.status).to.eq(403));
+        });
+      });
     });
   });
 });

--- a/apps/backend-e2e/src/e2e/project.cy.ts
+++ b/apps/backend-e2e/src/e2e/project.cy.ts
@@ -522,6 +522,18 @@ describe('PROJECT ACTIONS', () => {
       expect(response.body).to.be.an('array');
     });
   });
+
+  it("A visitor mustn't see any draft projects", () => {
+    cy.request({
+      method: 'GET',
+      url: '/api/projects',
+    }).then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.be.an('array');
+      response.body.forEach(({ draft }) => expect(draft).to.be.false);
+    });
+  });
+
   it('Should not fail when requesting a project.', () => {
     cy.login(Cypress.env('editor_credentials'));
     cy.authenticatedRequest({

--- a/apps/backend-e2e/src/e2e/project.cy.ts
+++ b/apps/backend-e2e/src/e2e/project.cy.ts
@@ -2,9 +2,6 @@ import type { CreateProjectDto, UpdateProjectDto } from '@datatlas/dtos';
 
 describe('PROJECT ACTIONS', () => {
   // DATA
-  let jwtAdmin;
-  let jwtEditor;
-  let idAdmin;
   const fakeProject = {
     title: 'string',
     draft: true,
@@ -470,37 +467,6 @@ describe('PROJECT ACTIONS', () => {
 
   let fakeProjectId;
 
-  // AUTHENTICATION
-  it('Connecting correctly with admin user.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        email: 'admin@example.org',
-        password: 'admin',
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(201);
-      jwtAdmin = response.body.access_token;
-      idAdmin = response.body.id;
-    });
-  });
-  it('Connecting correctly with editor user.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        email: 'editor@example.org',
-        password: 'editor',
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(201);
-      jwtEditor = response.body.access_token;
-    });
-  });
-
   // CREATE
   it('Should fail when creating new project without authentication.', () => {
     cy.request({
@@ -526,28 +492,22 @@ describe('PROJECT ACTIONS', () => {
     });
   });
   it('Should not fail when creating a project as an admin.', () => {
-    cy.request({
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
       method: 'POST',
       url: '/api/projects',
       body: fakeProject,
-      auth: {
-        bearer: jwtAdmin,
-      },
-      failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(201);
       fakeProjectId = response.body.id;
     });
   });
   it('Should not fail when creating a project as an editor.', () => {
-    cy.request({
+    cy.login(Cypress.env('editor_credentials'));
+    cy.authenticatedRequest({
       method: 'POST',
       url: '/api/projects',
       body: fakeProject,
-      auth: {
-        bearer: jwtEditor,
-      },
-      failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(201);
     });
@@ -555,43 +515,34 @@ describe('PROJECT ACTIONS', () => {
 
   // READ TODO waiting for answers about granularity af reading rights.
   it('Should not fail when requesting projects.', () => {
-    cy.request({
+    cy.login(Cypress.env('editor_credentials'));
+    cy.authenticatedRequest({
       method: 'GET',
       url: '/api/projects',
-      auth: {
-        bearer: jwtEditor,
-      },
-      failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(200);
       expect(response.body).to.be.an('array');
     });
   });
   it('Should not fail when requesting a project.', () => {
-    cy.request({
+    cy.login(Cypress.env('editor_credentials'));
+    cy.authenticatedRequest({
       method: 'GET',
       url: `/api/projects/${fakeProjectId}`,
-      auth: {
-        bearer: jwtEditor,
-      },
-      failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(200);
       expect(response.body.id).to.eq(fakeProjectId);
     });
   });
 
-  // UODATE
+  // UPDATE
   it('Should not fail when updating owned project as admin.', () => {
     fakeProject2.id = fakeProjectId;
-    cy.request({
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
       method: 'PUT',
       url: `/api/projects/${String(fakeProjectId)}`,
       body: fakeProject2,
-      auth: {
-        bearer: jwtAdmin,
-      },
-      failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(200);
       expect(response.body.id).to.eq(fakeProjectId);
@@ -600,10 +551,10 @@ describe('PROJECT ACTIONS', () => {
 
   // DELETE
   it('Should ot fail when trying to delete project as admin', () => {
-    cy.request({
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
       method: 'DELETE',
       url: `/api/projects/${fakeProjectId}`,
-      failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(200);
       expect(response.body).to.be.a('string');

--- a/apps/backend-e2e/src/e2e/user.cy.ts
+++ b/apps/backend-e2e/src/e2e/user.cy.ts
@@ -2,168 +2,27 @@ import type { CreateUserDto, GetUserDto } from '@datatlas/dtos';
 import { Roles } from '@datatlas/models';
 import { faker } from '@faker-js/faker';
 
-describe('USER ACTIONS', () => {
+describe('User operations', () => {
   // DATA
-  const user_test_editor: CreateUserDto = {
+  const createEditorPayload: CreateUserDto = {
     email: faker.internet.email(),
     password: faker.internet.password(),
     role: Roles.EDITOR,
     active: true,
   };
-  const user_test_admin: CreateUserDto = {
+  const createAdminPayload: CreateUserDto = {
     email: faker.internet.email(),
     password: faker.internet.password(),
     role: Roles.ADMIN,
     active: true,
   };
-  let editorToken: string;
-  let adminToken: string;
-  let editorId: number;
-  let adminId: number;
-  let createdEditorId: number;
-  let createdAdminId: number;
-  // AUTHENTICATION
-  it('Should fail when trying to connect without any credentials 1/2.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {},
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(401);
-    });
-  });
-  it('Should fail when trying to connect without any credentials 2/2.', () => {
-    cy.request({
-      method: 'GET',
-      url: '/api/auth/login',
-      body: {},
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(404);
-    });
-  });
-  it('Should fail when trying to connect without any data 1/2.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(401);
-    });
-  });
-  it('Should fail when trying to connect without any data 2/2.', () => {
-    cy.request({
-      method: 'GET',
-      url: '/api/auth/login',
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(404);
-    });
-  });
-  it('Should fail when trying to connect incomplete credentials 1/2.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        email: 'wrong_email',
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(401);
-    });
-  });
-  it('Should fail when trying to connect incomplete credentials 2/2.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        password: 'wrong_password',
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(401);
-    });
-  });
-  it('Should fail when trying to connect incorrect credentials 1.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        email: 'wrong@email.org',
-        password: 'incoherent_password',
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(401);
-    });
-  });
-  it('Should fail when trying to connect incorrect credentials 2 (incorrect password).', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        email: 'editor@example.org',
-        password: 'incorrect_password',
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(401);
-    });
-  });
-  it('Should fail when trying to connect incorrect credentials 3 (correct password but incorrect username).', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        email: 'editor@example.org_',
-        password: 'editor',
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(401);
-    });
-  });
-  it('Should returns a user id and token when trying to connect with proper editor credentials.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        email: 'editor@example.org',
-        password: 'editor',
-      },
-      failOnStatusCode: false,
-    }).then((response: Cypress.Response<{ access_token: string; user_id: number }>) => {
-      expect(response.status).to.eq(201);
-      expect(response.body.access_token).to.be.a('string');
-      expect(response.body.user_id).to.be.a('number');
-      editorToken = response.body.access_token;
-      editorId = response.body.user_id;
-    });
-  });
-  it('Should returns a user id and token when trying to connect with proper admin credentials.', () => {
-    cy.request({
-      method: 'POST',
-      url: '/api/auth/login',
-      body: {
-        email: 'admin@example.org',
-        password: 'admin',
-      },
-      failOnStatusCode: false,
-    }).then((response: Cypress.Response<{ access_token: string; user_id: number }>) => {
-      expect(response.status).to.eq(201);
-      expect(response.body.access_token).to.be.a('string');
-      expect(response.body.user_id).to.be.a('number');
-      adminToken = response.body.access_token;
-      adminId = response.body.user_id;
-    });
-  });
+
   // CREATE
   it('Should fail when trying to create user without authentication.', () => {
     cy.request({
       method: 'POST',
       url: '/api/users',
-      body: user_test_editor,
+      body: createEditorPayload,
       failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(403);
@@ -173,7 +32,7 @@ describe('USER ACTIONS', () => {
     cy.request({
       method: 'POST',
       url: '/api/users',
-      body: user_test_editor,
+      body: createEditorPayload,
       auth: {
         bearer: '',
       },
@@ -186,7 +45,7 @@ describe('USER ACTIONS', () => {
     cy.request({
       method: 'POST',
       url: '/api/users',
-      body: user_test_editor,
+      body: createEditorPayload,
       auth: {
         bearer: 'incorrect_token',
       },
@@ -195,30 +54,25 @@ describe('USER ACTIONS', () => {
       expect(response.status).to.eq(403);
     });
   });
-  it('Should fail when trying to create user with editor bearer token.', () => {
-    cy.request({
+  it('Should fail when trying to create user as an editor.', () => {
+    cy.login(Cypress.env('editor_credentials'));
+    cy.authenticatedRequest({
       method: 'POST',
       url: '/api/users',
-      body: user_test_editor,
-      auth: {
-        bearer: editorToken,
-      },
-      failOnStatusCode: false,
+      body: createEditorPayload,
     }).then((response) => {
       expect(response.status).to.eq(403);
     });
   });
   it('Should fail when sending incomplete data for user creation.', () => {
-    cy.request({
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
       method: 'POST',
       url: '/api/users',
       body: {
         password: faker.internet.password(),
         role: Roles.EDITOR,
         active: true,
-      },
-      auth: {
-        bearer: adminToken,
       },
       failOnStatusCode: false,
     }).then((response) => {
@@ -226,247 +80,262 @@ describe('USER ACTIONS', () => {
     });
   });
   it('Should return new user when trying to create user with admin bearer token.', () => {
-    cy.request({
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
       method: 'POST',
       url: '/api/users',
-      body: user_test_editor,
-      auth: {
-        bearer: adminToken,
-      },
-      failOnStatusCode: false,
+      body: createEditorPayload,
     }).then((response) => {
       expect(response.status).to.eq(201);
       expect(response.body.id).to.be.a('number').greaterThan(0);
-      expect(response.body.role).to.eq(user_test_editor.role);
-      expect(response.body.email).to.eq(user_test_editor.email);
-      expect(response.body.active).to.eq(user_test_editor.active);
-      createdEditorId = response.body.id;
+      expect(response.body.role).to.eq(createEditorPayload.role);
+      expect(response.body.email).to.eq(createEditorPayload.email);
+      expect(response.body.active).to.eq(createEditorPayload.active);
     });
   });
-  it('Should return new user when trying to create an admin user with admin bearer token.', () => {
-    cy.request({
+  it('Should return new user when trying to create an admin user, as an admin.', () => {
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
       method: 'POST',
       url: '/api/users',
-      body: user_test_admin,
-      auth: {
-        bearer: adminToken,
-      },
-      failOnStatusCode: false,
+      body: createAdminPayload,
     }).then((response: Cypress.Response<GetUserDto>) => {
       expect(response.status).to.eq(201);
       expect(response.body.id).to.be.a('number').greaterThan(0);
-      expect(response.body.role).to.eq(user_test_admin.role);
-      expect(response.body.email).to.eq(user_test_admin.email);
-      expect(response.body.active).to.eq(user_test_admin.active);
-      createdAdminId = response.body.id;
+      expect(response.body.role).to.eq(createAdminPayload.role);
+      expect(response.body.email).to.eq(createAdminPayload.email);
+      expect(response.body.active).to.eq(createAdminPayload.active);
     });
   });
-  it('Should fail when trying to add user with already used email (with admin bearer token).', () => {
-    cy.request({
+  it('Should fail when trying to add user with already used email, as an admin', () => {
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
       method: 'POST',
       url: '/api/users',
-      body: user_test_editor,
-      auth: {
-        bearer: adminToken,
-      },
+      body: createEditorPayload,
       failOnStatusCode: false,
     }).then((response) => {
       expect(response.status).to.eq(400);
     });
   });
   // READ
-  it('Should return data user when requesting info about himself as an editor.', () => {
-    cy.request({
-      method: 'GET',
-      url: `/api/users/${editorId}`,
-      failOnStatusCode: false,
-      auth: {
-        bearer: editorToken,
-      },
-    }).then((response: Cypress.Response<GetUserDto>) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.id).to.be.a('number').greaterThan(0);
-      expect(response.body.email).to.eq('editor@example.org');
-      expect(response.body.role).to.eq('EDITOR');
-      expect(response.body.active).to.eq('true');
+  it('Request self data as an editor.', () => {
+    cy.login(Cypress.env('editor_credentials')).then(() => {
+      cy.authenticatedRequest({
+        method: 'GET',
+        url: `/api/users/${window.localStorage.getItem('userId')}`,
+      }).then((response: Cypress.Response<GetUserDto>) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.id).to.be.a('number').greaterThan(0);
+        expect(response.body.email).to.eq(Cypress.env('editor_credentials').email);
+        expect(response.body.role).to.eq(Roles.EDITOR);
+        expect(response.body.active).to.eq(true);
+      });
     });
   });
   it('Should fail when requesting info about another user as an editor.', () => {
-    cy.request({
-      method: 'GET',
-      url: `/api/users/${createdEditorId}`,
-      failOnStatusCode: false,
-      auth: {
-        bearer: editorToken,
-      },
-    }).then((response) => {
-      expect(response.status).to.eq(403);
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
+      method: 'POST',
+      url: '/api/users',
+      body: { ...createEditorPayload, email: faker.internet.email() },
+    }).then((response: Cypress.Response<GetUserDto>) => {
+      cy.login(Cypress.env('editor_credentials'));
+      cy.authenticatedRequest({
+        method: 'GET',
+        url: `/api/users/${response.body.id}`,
+      }).then((response) => {
+        expect(response.status).to.eq(403);
+      });
     });
   });
   it('Should return data user when requesting info about himself as an admin.', () => {
-    cy.request({
-      method: 'GET',
-      url: `/api/users/${adminId}`,
-      failOnStatusCode: false,
-      auth: {
-        bearer: adminToken,
-      },
-    }).then((response: Cypress.Response<GetUserDto>) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.id).to.be.a('number').greaterThan(0);
-      expect(response.body.email).to.eq('admin@example.org');
-      expect(response.body.role).to.eq('ADMIN');
-      expect(response.body.active).to.eq('true');
+    cy.login(Cypress.env('admin_credentials')).then(() => {
+      cy.authenticatedRequest({
+        method: 'GET',
+        url: `/api/users/${window.localStorage.getItem('userId')}`,
+      }).then((response: Cypress.Response<GetUserDto>) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.id).to.be.a('number').greaterThan(0);
+        expect(response.body.email).to.eq(Cypress.env('admin_credentials').email);
+        expect(response.body.role).to.eq(Roles.ADMIN);
+        expect(response.body.active).to.eq(true);
+      });
     });
   });
   it('Should return data user when requesting info about another user as an admin.', () => {
-    cy.request({
-      method: 'GET',
-      url: `/api/users/${createdEditorId}`,
-      failOnStatusCode: false,
-      auth: {
-        bearer: adminToken,
-      },
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
+      method: 'POST',
+      url: '/api/users',
+      body: { ...createEditorPayload, email: faker.internet.email() },
     }).then((response: Cypress.Response<GetUserDto>) => {
-      expect(response.status).to.eq(200);
       expect(response.body.id).to.be.a('number').greaterThan(0);
-      expect(response.body.email).to.eq(user_test_editor.email);
-      expect(response.body.role).to.eq(user_test_editor.role);
-      expect(response.body.active).to.eq('true');
+      cy.authenticatedRequest({
+        method: 'GET',
+        url: `/api/users/${response.body.id}`,
+      }).then((response: Cypress.Response<GetUserDto>) => {
+        expect(response.status).to.eq(200);
+      });
     });
   });
   it('Should return data from all users when requesting them as an admin.', () => {
-    cy.request({
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
       method: 'GET',
       url: `/api/users/`,
       failOnStatusCode: false,
-      auth: {
-        bearer: adminToken,
-      },
     }).then((response: Cypress.Response<GetUserDto[]>) => {
       expect(response.status).to.eq(200);
-      expect(response.body).to.be.a('array');
+      expect(response.body).to.be.an('array');
     });
   });
   it('Should fail when trying to get all users as an editor.', () => {
-    cy.request({
+    cy.login(Cypress.env('editor_credentials'));
+    cy.authenticatedRequest({
       method: 'GET',
       url: `/api/users/`,
-      failOnStatusCode: false,
-      auth: {
-        bearer: editorToken,
-      },
     }).then((response: Cypress.Response<GetUserDto[]>) => {
       expect(response.status).to.eq(403);
     });
   });
   // UPDATE
-  it('Should return data user when updating its data with admin bearer token.', () => {
-    const mail = faker.internet.email();
-    cy.request({
-      method: 'PUT',
-      url: `/api/users/${createdEditorId}`,
-      body: {
-        email: mail,
-        password: faker.internet.password(),
-        role: Roles.EDITOR,
-        active: true,
-      },
-      auth: {
-        bearer: adminToken,
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.email).to.eq(mail);
-      expect(response.body.role).to.eq(Roles.EDITOR);
-      expect(response.body.active).to.eq(true);
-      expect(response.body.id).to.eq(String(createdEditorId));
+  it('An admin may update his/her own data.', () => {
+    cy.login(Cypress.env('admin_credentials')).then(() => {
+      const name = faker.name.fullName();
+      cy.authenticatedRequest({
+        method: 'PUT',
+        url: `/api/users/${window.localStorage.getItem('userId')}`,
+        body: {
+          name,
+          ...Cypress.env('admin_credentials'),
+          active: true,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.name).to.eq(name);
+      });
     });
   });
-  it('Should return data user when an editor tries to update his/her own data.', () => {
-    const mail = faker.internet.email();
-    cy.request({
-      method: 'PUT',
-      url: `/api/users/${editorId}`,
-      body: {
-        email: mail,
-        password: faker.internet.password(),
-        role: Roles.EDITOR,
-        active: true,
-      },
-      auth: {
-        bearer: editorToken,
-      },
-      failOnStatusCode: false,
+  it('An admin may NOT update another user data.', () => {
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
+      method: 'POST',
+      url: '/api/users',
+      body: { ...createEditorPayload, email: faker.internet.email() },
     }).then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body.email).to.eq(mail);
-      expect(response.body.role).to.eq(Roles.EDITOR);
-      expect(response.body.active).to.eq(true);
-      expect(response.body.id).to.eq(String(editorId));
+      const name = faker.name.fullName();
+      cy.authenticatedRequest({
+        method: 'PUT',
+        url: `/api/users/${response.body.id}`,
+        body: {
+          name,
+          email: faker.internet.email(),
+          password: faker.internet.password(),
+          active: true,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.name).to.eq(name);
+      });
     });
   });
-  it('Should fail when an editor tries to modify another user.', () => {
+  it('And editor may update his/her own data', () => {
+    cy.login(Cypress.env('editor_credentials')).then(() => {
+      const name = faker.name.fullName();
+      cy.authenticatedRequest({
+        method: 'PUT',
+        url: `/api/users/${window.localStorage.getItem('userId')}`,
+        body: {
+          name,
+          ...Cypress.env('editor_credentials'),
+          active: true,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+        expect(response.body.name).to.eq(name);
+      });
+    });
+  });
+  it('Should fail when an editor tries to modify another user', () => {
     const mail = faker.internet.email();
-    cy.request({
-      method: 'PUT',
-      url: `/api/users/${createdEditorId}`,
-      body: {
-        email: mail,
-        password: faker.internet.password(),
-        role: Roles.EDITOR,
-        active: true,
-      },
-      auth: {
-        bearer: editorToken,
-      },
-      failOnStatusCode: false,
+    cy.login(Cypress.env('editor_credentials'));
+    cy.authenticatedRequest({
+      method: 'POST',
+      url: '/api/users',
+      body: { ...createEditorPayload, email: faker.internet.email() },
     }).then((response) => {
-      expect(response.status).to.eq(403);
+      cy.authenticatedRequest({
+        method: 'PUT',
+        url: `/api/users/${response.body.id}`,
+        body: {
+          email: mail,
+          password: faker.internet.password(),
+          role: Roles.EDITOR,
+          active: true,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(403);
+      });
     });
   });
   it('Should fail when updating user with already used email.', () => {
-    cy.request({
-      method: 'PUT',
-      url: `/api/users/${createdEditorId}`,
-      body: {
-        email: 'admin@example.org',
-        password: faker.internet.password(),
-        role: Roles.EDITOR,
-        active: true,
-      },
-      auth: {
-        bearer: adminToken,
-      },
-      failOnStatusCode: false,
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
+      method: 'POST',
+      url: '/api/users',
+      body: createEditorPayload,
     }).then((response) => {
-      expect(response.status).to.eq(400);
+      cy.authenticatedRequest({
+        method: 'PUT',
+        url: `/api/users/${response.body.id}`,
+        body: {
+          email: 'admin@example.org',
+          password: faker.internet.password(),
+          role: Roles.EDITOR,
+          active: true,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(400);
+      });
     });
   });
   // DELETE
-  it('Should fail when an editor tries to delete any user.', () => {
-    cy.request({
-      method: 'DELETE',
-      url: `/api/users/${createdEditorId}`,
-      auth: {
-        bearer: editorToken,
-      },
-      failOnStatusCode: false,
+  it('Should fail when an editor tries to delete any user', () => {
+    cy.login(Cypress.env('admin_credentials'));
+    cy.authenticatedRequest({
+      method: 'POST',
+      url: '/api/users',
+      body: { ...createEditorPayload, email: faker.internet.email() },
     }).then((response) => {
-      expect(response.status).to.eq(403);
+      cy.log(JSON.stringify(response.body));
+      expect(response.body.id).to.be.a('number').greaterThan(0);
+      cy.login(Cypress.env('editor_credentials')).then(() => {
+        cy.authenticatedRequest({
+          method: 'DELETE',
+          url: `/api/users/${response.body.id}`,
+          failOnStatusCode: false,
+        }).then((response) => {
+          expect(response.status).to.eq(403);
+        });
+      });
     });
   });
-  it('Should return HTML code 204 when admin suppresses a user.', () => {
-    cy.request({
-      method: 'DELETE',
-      url: `/api/users/${createdEditorId}`,
-      auth: {
-        bearer: adminToken,
-      },
-      failOnStatusCode: false,
-    }).then((response) => {
-      expect(response.status).to.eq(204);
+  it('An admin may delete any user', () => {
+    cy.login(Cypress.env('admin_credentials')).then(() => {
+      cy.authenticatedRequest({
+        method: 'POST',
+        url: '/api/users',
+        body: { ...createEditorPayload, email: faker.internet.email() },
+      }).then((response: Cypress.Response<GetUserDto>) => {
+        expect(response.body.id).to.be.a('number').greaterThan(0);
+        cy.authenticatedRequest({
+          method: 'DELETE',
+          url: `/api/users/${response.body.id}`,
+        }).then((response) => {
+          expect(response.status).to.eq(204);
+        });
+      });
     });
   });
 });

--- a/apps/backend-e2e/src/support/e2e.ts
+++ b/apps/backend-e2e/src/support/e2e.ts
@@ -15,3 +15,4 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
+require('cypress-terminal-report/src/installLogsCollector')();

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -35,14 +35,14 @@ export class AuthService {
     };
   }
 
-  async getLoggedUserCredentials(request): Promise<UserCredentials> {
+  async getLoggedUserCredentials(request): Promise<UserCredentials | null> {
     const { headers } = request;
     if (!headers['authorization']) {
       return null;
     }
     const headerString = headers['authorization'].split(' ');
     if (headerString.length !== 2) {
-      // No bearer token fount.
+      // No bearer token found.
       return null;
     }
     const decode = this.jwtService.decode(headerString[1]);

--- a/apps/backend/src/project/guards/can-see-project.guard.ts
+++ b/apps/backend/src/project/guards/can-see-project.guard.ts
@@ -1,0 +1,30 @@
+import { AuthGuard } from '@nestjs/passport';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Roles } from '@datatlas/models';
+import { AuthService } from '../../auth/auth.service';
+import { ProjectService } from '../project.service';
+
+@Injectable()
+export class CanSeeProjectGuard extends AuthGuard('local') {
+  constructor(
+    private readonly _reflector: Reflector,
+    private authService: AuthService,
+    private readonly projectService: ProjectService
+  ) {
+    super();
+  }
+  async canActivate(context: ExecutionContext) {
+    const request = context.switchToHttp().getRequest();
+    const project = await this.projectService.findOneById(parseInt(request.params.id));
+
+    if (project.draft) {
+      const userCredentials = await this.authService.getLoggedUserCredentials(request);
+      if (!userCredentials || (userCredentials.id !== project.owner.id && userCredentials.role !== Roles.ADMIN)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}

--- a/apps/backend/src/project/project.controller.ts
+++ b/apps/backend/src/project/project.controller.ts
@@ -1,17 +1,6 @@
-import {
-  Controller,
-  Post,
-  Body,
-  UseGuards,
-  Get,
-  Param,
-  Put,
-  Delete,
-  Req,
-  NotFoundException,
-  Logger,
-} from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, Get, Param, Put, Delete, Req, NotFoundException } from '@nestjs/common';
 import { CreateProjectDto, UpdateProjectDto } from '@datatlas/dtos';
+import { UserCredentials } from '@datatlas/models';
 import { ProjectService } from './project.service';
 import { UserService } from '../user/user.service';
 import { ValidJwtGuard } from '../auth/validJwt.guard';
@@ -20,7 +9,7 @@ import { ProjectEntity } from './entities/project.entity';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { CanEditProjectGuard } from '../auth/can-edit-project.guard';
 import { AuthService } from '../auth/auth.service';
-import { UserCredentials } from '@datatlas/models';
+import { CanSeeProjectGuard } from './guards/can-see-project.guard';
 
 @ApiBearerAuth()
 @Controller('projects')
@@ -51,6 +40,7 @@ export class ProjectController {
   }
 
   @Get(':id')
+  @UseGuards(CanSeeProjectGuard)
   async fetchOne(@Param('id') id: number): Promise<ProjectEntity> {
     const project = await this.projectService.findOneById(id);
     if (project === null) {

--- a/apps/backend/src/project/project.service.ts
+++ b/apps/backend/src/project/project.service.ts
@@ -26,7 +26,11 @@ export class ProjectService {
     return project;
   }
 
-  async findAll(userCredentials: UserCredentials): Promise<ProjectEntity[]> {
+  async findAll(userCredentials: UserCredentials | null): Promise<ProjectEntity[]> {
+    if (!userCredentials) {
+      return await this.projectRepository.find({ draft: false });
+    }
+
     // As admin, we want all projects (including drafts).
     if (userCredentials.role === Roles.ADMIN) {
       return this.projectRepository.findAll();

--- a/apps/backend/src/user/entities/user.entity.ts
+++ b/apps/backend/src/user/entities/user.entity.ts
@@ -23,7 +23,7 @@ export class UserEntity implements Partial<UserInterface> {
   @Property()
   role: Roles = Roles.EDITOR;
 
-  @Property()
+  @Property({ type: 'boolean' })
   active = true;
 
   constructor(user: UserInterface) {

--- a/apps/backend/src/user/user.service.ts
+++ b/apps/backend/src/user/user.service.ts
@@ -59,9 +59,9 @@ export class UserService {
   }
 
   async updateUser(updateUserDto: UpdateUserDto & { id: number }): Promise<GetUserDto> {
-    const alreadyExists = await this.isEmailAlreadyInDatabase(updateUserDto.email);
-    if (alreadyExists) {
-      throw new HttpException(`User already exists.`, 400);
+    const userWithSameEmail = await this.userRepository.findOne({ email: updateUserDto.email });
+    if (userWithSameEmail && userWithSameEmail.id !== updateUserDto.id) {
+      throw new HttpException(`Email already in use.`, 400);
     }
 
     if (updateUserDto.password) {

--- a/libs/dtos/src/user/update-user.dto.ts
+++ b/libs/dtos/src/user/update-user.dto.ts
@@ -3,6 +3,7 @@ import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class UpdateUserDto implements Partial<UserInterface> {
   @IsString()
+  @IsOptional()
   readonly email?: string;
 
   @IsString()
@@ -10,11 +11,12 @@ export class UpdateUserDto implements Partial<UserInterface> {
   readonly name?: string;
 
   @IsString()
+  @IsOptional()
   password?: string;
 
   @IsString()
   @IsOptional()
-  readonly role?: Roles = Roles.EDITOR;
+  readonly role?: Roles;
 
   @IsBoolean()
   @IsOptional()

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,7 @@
         "vite-plugin-eslint": "^1.8.1",
         "vite-tsconfig-paths": "^4.0.2",
         "vitest": "^0.25.8",
+        "wait-on": "^7.0.1",
         "web-vitals": "^3.1.0",
         "whatwg-fetch": "^3.6.2"
       },
@@ -3641,6 +3642,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@docusaurus/core/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
+      }
+    },
     "node_modules/@docusaurus/core/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3795,6 +3804,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/wait-on": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.1.tgz",
+      "integrity": "sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==",
+      "dependencies": {
+        "axios": "^0.25.0",
+        "joi": "^17.6.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.5",
+        "rxjs": "^7.5.4"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/core/node_modules/yallist": {
@@ -44485,29 +44512,46 @@
       }
     },
     "node_modules/wait-on": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.1.tgz",
-      "integrity": "sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
+      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "dev": true,
       "dependencies": {
-        "axios": "^0.25.0",
-        "joi": "^17.6.0",
+        "axios": "^0.27.2",
+        "joi": "^17.7.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.5",
-        "rxjs": "^7.5.4"
+        "minimist": "^1.2.7",
+        "rxjs": "^7.8.0"
       },
       "bin": {
         "wait-on": "bin/wait-on"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/wait-on/node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/wait-on/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/walker": {
@@ -48426,6 +48470,14 @@
             "color-convert": "^2.0.1"
           }
         },
+        "axios": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+          "requires": {
+            "follow-redirects": "^1.14.7"
+          }
+        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -48541,6 +48593,18 @@
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "wait-on": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.1.tgz",
+          "integrity": "sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==",
+          "requires": {
+            "axios": "^0.25.0",
+            "joi": "^17.6.0",
+            "lodash": "^4.17.21",
+            "minimist": "^1.2.5",
+            "rxjs": "^7.5.4"
           }
         },
         "yallist": {
@@ -78775,23 +78839,37 @@
       }
     },
     "wait-on": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.1.tgz",
-      "integrity": "sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
+      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "dev": true,
       "requires": {
-        "axios": "^0.25.0",
-        "joi": "^17.6.0",
+        "axios": "^0.27.2",
+        "joi": "^17.7.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.5",
-        "rxjs": "^7.5.4"
+        "minimist": "^1.2.7",
+        "rxjs": "^7.8.0"
       },
       "dependencies": {
         "axios": {
-          "version": "0.25.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "dev": true,
           "requires": {
-            "follow-redirects": "^1.14.7"
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,7 @@
         "cross-env": "^7.0.3",
         "customize-cra": "^1.0.0",
         "cypress": "^12.2.0",
+        "cypress-terminal-report": "^5.3.6",
         "eslint": "~8.15.0",
         "eslint-config-prettier": "8.1.0",
         "eslint-config-react-app": "^7.0.1",
@@ -17092,6 +17093,139 @@
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
+    },
+    "node_modules/cypress-terminal-report": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-5.3.6.tgz",
+      "integrity": "sha512-peKFSqxL9CDh/DHqahtbpF+vUZNiBW1N2HhlovpE8VGthuz7fM7hOyk5Bu/3llCP6PkQvvbIs/G0gxMfG5XKmA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "process": "^0.11.10",
+        "semver": "^7.3.5",
+        "tv4": "^1.3.0"
+      },
+      "peerDependencies": {
+        "cypress": ">=10.0.0"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/cypress-terminal-report/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cypress-terminal-report/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/cypress/node_modules/@types/node": {
       "version": "14.18.36",
@@ -43121,6 +43255,15 @@
         "node": "*"
       }
     },
+    "node_modules/tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -58545,6 +58688,105 @@
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
           "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "cypress-terminal-report": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/cypress-terminal-report/-/cypress-terminal-report-5.3.6.tgz",
+      "integrity": "sha512-peKFSqxL9CDh/DHqahtbpF+vUZNiBW1N2HhlovpE8VGthuz7fM7hOyk5Bu/3llCP6PkQvvbIs/G0gxMfG5XKmA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "process": "^0.11.10",
+        "semver": "^7.3.5",
+        "tv4": "^1.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -77712,6 +77954,12 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==",
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "cross-env": "^7.0.3",
     "customize-cra": "^1.0.0",
     "cypress": "^12.2.0",
+    "cypress-terminal-report": "^5.3.6",
     "eslint": "~8.15.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-config-react-app": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "vite-plugin-eslint": "^1.8.1",
     "vite-tsconfig-paths": "^4.0.2",
     "vitest": "^0.25.8",
+    "wait-on": "^7.0.1",
     "web-vitals": "^3.1.0",
     "whatwg-fetch": "^3.6.2"
   },


### PR DESCRIPTION
> Fix #220 

> Most of this PR is quite off topic but since e2e tests weren't launched in a while, I had to carry out some refactoring :
> - use existing environment variables in cypress instead of hard coded credentials
> - leverage __Cypress__ session mechanism to cache authentication requests
> - fix some tests which could failed when run in parallel (by enforcing tests isolations).
>
> Hopefully it won't happens again since e2e tests are now run in CI.

Forbid access to draft projects from any users except owner & admin.