### PR TITLE
feat(layer-color): keep layer and dataset color in sync

### DIFF
--- a/apps/frontend/src/components/keplerGl/factories/FilterManagerFactory.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/FilterManagerFactory.tsx
@@ -82,7 +82,7 @@ function FilterManagerFactory(SourceDataCatalog, FilterPanel) {
                   <LayerPanelHeader
                     isActive={layer.config.isConfigActive}
                     isDragNDropEnabled={true}
-                    labelRCGColorValues={layer.config.dataId ? datasets[layer.config.dataId].color : null}
+                    labelRCGColorValues={layer.config.color}
                     onToggleEnableConfig={handleToggleLayerPanel(layer)}
                     layerTitleSection={
                       <LayerTitleSection

--- a/apps/frontend/src/components/keplerGl/factories/LayerPanelFactory.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/LayerPanelFactory.tsx
@@ -1,11 +1,9 @@
 import React, { CSSProperties, UIEventHandler } from 'react';
-import { Layer } from 'kepler.gl';
+import { Datasets, Layer } from 'kepler.gl';
 import { LayerPanelFactory as KeplerLayerPanelFactory } from 'kepler.gl/components';
-import { PanelWrapper } from '../side-panel/layer/LayerPanel';
-import { Datasets } from 'kepler.gl';
 import { visStateActions } from 'kepler.gl/actions';
-import { LayerTypeOptionInterface } from '../types/LayerTypeOptionInterface';
-import { PanelComponentPropsInterface } from '../types/PanelComponentPropsInterface';
+import { PanelWrapper } from '../side-panel/layer/LayerPanel';
+import { LayerTypeOptionInterface, PanelComponentPropsInterface } from '../types';
 
 export interface KeplerLayerPanelPropsInterface {
   layer: Layer;
@@ -128,7 +126,7 @@ export const LayerPanelFactory = (KeplerLayerConfigurator, KeplerLayerPanelHeade
           layerId={layer.id}
           isVisible={config.isVisible}
           label={config.label}
-          labelRCGColorValues={config.dataId ? datasets[config.dataId].color : null}
+          labelRCGColorValues={config.color}
           layerType={layer.type}
           onToggleEnableConfig={_toggleEnableConfig}
           onToggleVisibility={_toggleVisibility}

--- a/apps/frontend/src/components/keplerGl/factories/side-panel/interaction-panel/InteractionPanelFactory.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/side-panel/interaction-panel/InteractionPanelFactory.tsx
@@ -22,6 +22,7 @@ interface InteractionPanelFactoryProps {
   config: InteractionConfig[keyof InteractionConfig];
   onConfigChange: (config: Partial<InteractionConfig[keyof InteractionConfig]>) => void;
 }
+
 const InteractionPanelFactory =
   (TooltipConfig: ComponentType<any>, BrushConfig: ComponentType<any>, FiltersConfig: ComponentType<any>) =>
   ({ datasets, config, onConfigChange }: InteractionPanelFactoryProps) => {

--- a/apps/frontend/src/store/reducers/keplerGl/index.ts
+++ b/apps/frontend/src/store/reducers/keplerGl/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-useless-computed-key */
 import { AnyAction, createAction, Reducer } from '@reduxjs/toolkit';
-import { registerEntry } from 'kepler.gl';
+import { Layer, registerEntry } from 'kepler.gl';
 import { KeplerGlState } from 'kepler.gl/reducers';
 import { keplerGlReducer } from './root';
 import { addDataToMap, setMapInfo, wrapTo, setLocale as setKeplerMapLocale } from 'kepler.gl/actions';
@@ -63,6 +63,28 @@ export const keplerReducer: Reducer<DatatlasGlState> = keplerGlReducer
         readOnly: action.payload,
       },
     }),
+    // When the color of layer change, propagate the color change to the dataset.
+    ['@@kepler.gl/LAYER_CONFIG_CHANGE']: (state, action: { oldLayer: Layer; newConfig: Partial<Layer> }) => {
+      if (!action?.newConfig?.color) {
+        return state;
+      }
+
+      const { color } = action.newConfig;
+      const { dataId } = action.oldLayer.config;
+      return {
+        ...state,
+        visState: {
+          ...state.visState,
+          datasets: {
+            ...state.visState.datasets,
+            [dataId]: {
+              ...state.visState.datasets[dataId],
+              color,
+            },
+          },
+        },
+      };
+    },
   });
 
 export const addProjectToKeplerState = (state: Record<string, KeplerGlState> = {}, projectDto: ProjectDto) =>


### PR DESCRIPTION
This partially fix #230 there are still edge cases persisting. Notably in `TooltipConfig` where the dataset color is used. This is fixable in the UI when we update a layer color because it also change the dataset color.

This could be totally fixed by using the same color as the dataset at layer creation time. (see #264 )