### PR TITLE
chore(docker): yet another fix for matomo env variable replacement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_MAPBOX_ACCESS_TOKEN="
 RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_DEFAULT_LOCALE="defaultLocale"' >> .env; fi
 RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_API_BASE_URL="defaultApiBaseUrl"' >> .env; fi
 RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_MATOMO_TRACKER_URL="REACT_APP_MATOMO_TRACKER_URL_DEFAULT_VALUE"' >> .env; fi
-RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'DEFAULT_REACT_APP_MATOMO_SITE_ID="DEFAULT_REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE"' >> .env; fi
+RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_MATOMO_SITE_ID="REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE"' >> .env; fi
 
 # Creates a "dist" folder with the production build
 RUN npx nx build $COPY_PATH

--- a/docker/nginx/entrypoint.sh
+++ b/docker/nginx/entrypoint.sh
@@ -13,8 +13,8 @@ sed -i "s#defaultApiBaseUrl#$REACT_APP_API_BASE_URL#g" /usr/share/nginx/html/sta
 # Matomo
 echo "Replacing REACT_APP_MATOMO_TRACKER_URL_DEFAULT_VALUE with $REACT_APP_MATOMO_TRACKER_URL"
 sed -i "s#REACT_APP_MATOMO_TRACKER_URL_DEFAULT_VALUE#$REACT_APP_MATOMO_TRACKER_URL#g" /usr/share/nginx/html/index.html
-echo "Replacing DEFAULT_REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE with $REACT_APP_MATOMO_SITE_ID"
-sed -i "s#DEFAULT_REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE#$REACT_APP_MATOMO_SITE_ID#g" /usr/share/nginx/html/index.html
+echo "Replacing REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE with $REACT_APP_MATOMO_SITE_ID"
+sed -i "s#REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE#$REACT_APP_MATOMO_SITE_ID#g" /usr/share/nginx/html/index.html
 
 # start nginx
 nginx -g 'daemon off;'


### PR DESCRIPTION
This one is actually just to set consistent naming scheme, shouldn't change a thing.