### PR TITLE
Add Grand Lyon map styles 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_MAPBOX_ACCESS_TOKEN="
 RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_DEFAULT_LOCALE="defaultLocale"' >> .env; fi
 RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_API_BASE_URL="defaultApiBaseUrl"' >> .env; fi
 RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_MATOMO_TRACKER_URL="REACT_APP_MATOMO_TRACKER_URL_DEFAULT_VALUE"' >> .env; fi
-RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'DEFAULT_REACT_APP_MATOMO_SITE_ID="DEFAULT_REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE"' >> .env; fi
+RUN if [ "$COPY_PATH" = "frontend" ]; then echo 'REACT_APP_MATOMO_SITE_ID="REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE"' >> .env; fi
 
 # Creates a "dist" folder with the production build
 RUN npx nx build $COPY_PATH

--- a/docker/nginx/entrypoint.sh
+++ b/docker/nginx/entrypoint.sh
@@ -13,8 +13,8 @@ sed -i "s#defaultApiBaseUrl#$REACT_APP_API_BASE_URL#g" /usr/share/nginx/html/sta
 # Matomo
 echo "Replacing REACT_APP_MATOMO_TRACKER_URL_DEFAULT_VALUE with $REACT_APP_MATOMO_TRACKER_URL"
 sed -i "s#REACT_APP_MATOMO_TRACKER_URL_DEFAULT_VALUE#$REACT_APP_MATOMO_TRACKER_URL#g" /usr/share/nginx/html/index.html
-echo "Replacing DEFAULT_REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE with $REACT_APP_MATOMO_SITE_ID"
-sed -i "s#DEFAULT_REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE#$REACT_APP_MATOMO_SITE_ID#g" /usr/share/nginx/html/index.html
+echo "Replacing REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE with $REACT_APP_MATOMO_SITE_ID"
+sed -i "s#REACT_APP_MATOMO_SITE_ID_DEFAULT_VALUE#$REACT_APP_MATOMO_SITE_ID#g" /usr/share/nginx/html/index.html
 
 # start nginx
 nginx -g 'daemon off;'

--- a/libs/models/kepler/KeplerMapStyle.ts
+++ b/libs/models/kepler/KeplerMapStyle.ts
@@ -8,6 +8,20 @@ import { getInitialInputStyle } from 'kepler.gl/dist/reducers/map-style-updaters
 export class KeplerMapStyle implements SavedMapStyle {
   public static readonly DEFAULT_MAP_STYLES: BaseMapStyle[] = [
     {
+      id: 'klokantech-basic',
+      label: 'Grand Lyon Basique',
+      url: 'https://openmaptiles.data.grandlyon.com/styles/klokantech-basic/style.json',
+      icon: 'https://openmaptiles.data.grandlyon.com/styles/klokantech-basic/11/1052/730.png',
+      layerGroups: [],
+    },
+    {
+      id: 'vector',
+      label: 'Grand Lyon Claire',
+      url: 'https://openmaptiles.data.grandlyon.com/styles/vector/style.json',
+      icon: 'https://openmaptiles.data.grandlyon.com/styles/vector/11/1050/729.png',
+      layerGroups: [],
+    },
+    {
       id: 'dark',
       label: 'Sombre',
       url: 'mapbox://styles/uberdata/cjoqbbf6l9k302sl96tyvka09',


### PR DESCRIPTION
You may now select Grand Lyon base map style for your map :
https://openmaptiles.data.grandlyon.com/

Grand Lyon Basic is now the default base map style.

> fix https://github.com/datatlas-erasme/datatlas/issues/219