### PR TITLE
feat: implement tooltip and detailed view of a POI

### DIFF
--- a/apps/frontend/src/components/ExternalLink.tsx
+++ b/apps/frontend/src/components/ExternalLink.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-useless-fragment */
 import React, { PropsWithChildren } from 'react';
 
 export const ExternalLink = ({ href, children }: PropsWithChildren<{ href?: string }>) =>

--- a/apps/frontend/src/components/ExternalLink.tsx
+++ b/apps/frontend/src/components/ExternalLink.tsx
@@ -1,0 +1,10 @@
+import React, { PropsWithChildren } from 'react';
+
+export const ExternalLink = ({ href, children }: PropsWithChildren<{ href?: string }>) =>
+  href ? (
+    <a target="_blank" rel="noopener noreferrer" href={href}>
+      {children}
+    </a>
+  ) : (
+    <>{children}</>
+  );

--- a/apps/frontend/src/components/buttons/Button.tsx
+++ b/apps/frontend/src/components/buttons/Button.tsx
@@ -7,11 +7,11 @@ interface ButtonPropsInterface extends ButtonHTMLAttributes<HTMLButtonElement> {
   Icon?: ReactElement;
   isInactive?: boolean;
   width?: string;
+  large?: boolean;
+  small?: boolean;
 }
 
-const StyledKeplerButton = styled(KeplerButton)`
-  margin: 10px;
-`;
+const StyledKeplerButton = styled(KeplerButton)``;
 export const Button = ({ children, Icon, ...props }: ButtonPropsInterface) => {
   return (
     <StyledKeplerButton {...props}>

--- a/apps/frontend/src/components/buttons/OutlineButton.tsx
+++ b/apps/frontend/src/components/buttons/OutlineButton.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import Button from './Button';
+
+export const OutlineButton = styled(Button)`
+  font-family: 'Roboto', Verdana, 'Helvetica Neue', Helvetica, sans-serif;
+  font-size: ${({ large, small, theme }) => (large ? '16px' : small ? '12px' : '14px')};
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: ${({ theme }) => theme.textColor};
+  padding: ${({ large, small }) => (large ? '14px 24px' : small ? '3px 10px' : '4px 14px')};
+
+  background-color: ${({ theme }) => theme.panelBackground};
+  border: 2px solid ${({ theme }) => theme.textColor};
+  border-radius: 20px;
+
+  :hover {
+    color: ${({ theme }) => theme.textColorHl};
+    background-color: ${({ theme }) => theme.panelBackground};
+    border: 2px solid ${({ theme }) => theme.textColorHl};
+  }
+`;

--- a/apps/frontend/src/components/buttons/StyledFormBtn.tsx
+++ b/apps/frontend/src/components/buttons/StyledFormBtn.tsx
@@ -10,6 +10,7 @@ export const StyledFormBtn = styled(({ loading, children, ...props }) => {
     </Button>
   );
 })`
+  background-color: black;
   margin: 20px auto;
   padding: 15px 42px;
   padding-left: ${({ loading }) => (loading ? '18px' : '42px')};

--- a/apps/frontend/src/components/buttons/index.ts
+++ b/apps/frontend/src/components/buttons/index.ts
@@ -2,5 +2,6 @@ export * from './IconButton';
 export * from './Button';
 export * from './GithubLink';
 export * from './DisplayButton';
+export * from './OutlineButton';
 export * from './SidePanelButton';
 export * from './StyledFormBtn';

--- a/apps/frontend/src/components/keplerGl/factories/map/LayerHoverInfo.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/map/LayerHoverInfo.tsx
@@ -1,0 +1,244 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import React from 'react';
+import styled from 'styled-components';
+import classNames from 'classnames';
+import { Layers } from 'kepler.gl/dist/components/common/icons';
+import { getTooltipDisplayValue, getTooltipDisplayDeltaValue } from 'kepler.gl/dist/utils/interaction-utils';
+import KeplerLayerHoverInfoFactory, { StyledLayerName } from 'kepler.gl/dist/components/map/layer-hover-info';
+import MapboxLayerGL from 'kepler.gl/src/layers/mapboxgl-layer';
+import { TooltipField } from 'kepler.gl/src/reducers/vis-state-updaters';
+import { DataRow } from 'kepler.gl/src/utils/table-utils/data-row';
+import { DataContainerInterface } from 'kepler.gl/src/utils/table-utils/data-container-interface';
+import { Field } from 'kepler.gl/src/utils/table-utils/kepler-table';
+import { CompareType } from '@datatlas/models';
+import { Button, OutlineButton } from '../../../buttons';
+import { ExternalLink } from '../../../ExternalLink';
+import { isImageURL, humanize } from '../../../../utils';
+
+export const MapPopoverContent = styled.div`
+  & .row__delta-value {
+    text-align: right;
+
+    &.positive {
+      color: ${(props) => props.theme.primaryBtnBgd};
+    }
+
+    &.negative {
+      color: ${(props) => props.theme.negativeBtnActBgd};
+    }
+  }
+`;
+
+interface RowProps extends Omit<ExpandedProps, 'setExpanded'> {
+  name: string;
+  value: number | string;
+  deltaValue?: number | string | null;
+  url?: string;
+}
+
+export const Row = ({ name, value, deltaValue, url, expanded }: RowProps) => {
+  // Set 'url' to 'value' if it looks like a url
+  if (!url && value && typeof value === 'string' && value.match(/^http/)) {
+    url = value;
+  }
+
+  const className = classNames(['row', !value && 'empty']);
+  const containerProps = {
+    className,
+    key: name,
+  };
+
+  // @todo We could also attempt to load the URL and see what's the content type.
+  const asImg = /<img>/.test(name) || isImageURL(value as string);
+  if (asImg) {
+    return (
+      <div {...containerProps} className={classNames([className, 'image-container'])}>
+        <ExternalLink href={url}>
+          <img src={value as string} alt={name} />
+        </ExternalLink>
+      </div>
+    );
+  }
+
+  const asTitle = name.indexOf('adresse') !== -1;
+  if (asTitle) {
+    return (
+      <div {...containerProps}>
+        <ExternalLink href={url}>{asTitle ? <h3>{value}</h3> : value}</ExternalLink>
+      </div>
+    );
+  }
+
+  return (
+    <dl {...containerProps}>
+      {!asTitle && <dt className="row__name">{humanize(name)}</dt>}
+      <dd className="row__value">
+        <ExternalLink href={url}>{value}</ExternalLink>
+      </dd>
+      {deltaValue && (
+        <dd className={`row__delta-value ${deltaValue.toString().charAt(0) === '+' ? 'positive' : 'negative'}`}>
+          {deltaValue}
+        </dd>
+      )}
+    </dl>
+  );
+};
+
+const EntryInfo = ({
+  fieldsToShow,
+  fields,
+  data,
+  primaryData,
+  compareType,
+  expanded,
+}: Omit<LayerHoverInfoProps, 'onClose'>) => (
+  <div className="entry-info">
+    {fieldsToShow.map((item) => (
+      <EntryInfoRow
+        key={item.name}
+        item={item}
+        fields={fields}
+        data={data}
+        primaryData={primaryData}
+        compareType={compareType}
+        expanded={expanded}
+      />
+    ))}
+  </div>
+);
+
+interface EntryInfoRowProps extends Omit<LayerHoverInfoProps, 'fieldsToShow' | 'layer' | 'setExpanded' | 'onClose'> {
+  item: TooltipField;
+}
+
+const EntryInfoRow = ({ item, fields, data, primaryData, compareType, expanded }: EntryInfoRowProps) => {
+  const fieldIdx = fields.findIndex((f) => f.name === item.name);
+  if (fieldIdx < 0) {
+    return null;
+  }
+  const field = fields[fieldIdx];
+  const displayValue = getTooltipDisplayValue({ item, field, data, fieldIdx });
+
+  const displayDeltaValue = getTooltipDisplayDeltaValue({
+    item,
+    field,
+    data,
+    fieldIdx,
+    primaryData,
+    compareType,
+  });
+
+  return (
+    <Row
+      name={field.displayName || field.name}
+      value={displayValue}
+      deltaValue={displayDeltaValue}
+      expanded={expanded}
+    />
+  );
+};
+
+// TODO: supporting comparative value for aggregated cells as well
+const CellInfo = ({ data, layer, expanded }: Omit<LayerHoverInfoProps, 'setExpanded'>) => {
+  const { colorField, sizeField } = layer.config;
+
+  return (
+    <>
+      <Row name={'total points'} key="count" value={data.points && data.points.length} expanded={expanded} />
+      {colorField && layer.visualChannels.color ? (
+        <Row
+          name={layer.getVisualChannelDescription('color').measure}
+          key="color"
+          value={data.colorValue || 'N/A'}
+          expanded={expanded}
+        />
+      ) : null}
+      {sizeField && layer.visualChannels.size ? (
+        <Row
+          name={layer.getVisualChannelDescription('size').measure}
+          key="size"
+          value={data.elevationValue || 'N/A'}
+          expanded={expanded}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export interface LayerHoverInfoProps extends ExpandedProps {
+  fields: Field[];
+  fieldsToShow: TooltipField[];
+  layer: MapboxLayerGL;
+  data: DataRow & {
+    points: any[];
+    elevationValue: string;
+    colorValue: string;
+  };
+  primaryData: DataContainerInterface;
+  compareType: CompareType | null;
+  onClose: () => void;
+}
+
+const MapPopoverActions = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Toolbar = styled.div``;
+
+interface ExpandedProps {
+  expanded: boolean;
+  setExpanded: (expanded: boolean) => void;
+}
+
+const LayerHoverInfoContainer = styled.div<Pick<LayerHoverInfoProps, 'layer'>>`
+  .map-popover__layer-name {
+    svg {
+      fill: ${({ layer }) => `rgb(${layer.config.color.join(',')})`};
+    }
+  }
+`;
+
+const LayerHoverInfoFactory = () => {
+  return (props: LayerHoverInfoProps) => {
+    const { data, layer, expanded, setExpanded, onClose } = props;
+    if (!data || !layer) {
+      return null;
+    }
+
+    return (
+      <LayerHoverInfoContainer
+        className={classNames(['map-popover__layer-info', expanded && 'expanded'])}
+        layer={layer}
+      >
+        <Toolbar className="map-popover__topbar">
+          <StyledLayerName className="map-popover__layer-name">
+            <Layers height="16px" style={{ fill: layer.config.color }} />
+            {props.layer.config.label}
+          </StyledLayerName>
+          <Button onClick={() => setExpanded(false)}>×</Button>
+        </Toolbar>
+
+        <MapPopoverContent className="map-popover__content">
+          {props.layer.isAggregated ? (
+            <CellInfo {...props} expanded={expanded} />
+          ) : (
+            <EntryInfo {...props} expanded={expanded} />
+          )}
+        </MapPopoverContent>
+        <MapPopoverActions className="map-popover__actions">
+          <OutlineButton onClick={onClose}>Fermer</OutlineButton>
+          <OutlineButton onClick={() => setExpanded(true)}>Voir la fiche détaillée</OutlineButton>
+        </MapPopoverActions>
+      </LayerHoverInfoContainer>
+    );
+  };
+};
+
+LayerHoverInfoFactory.deps = KeplerLayerHoverInfoFactory.deps;
+
+export function replaceLayerHoverInfoFactory() {
+  return [KeplerLayerHoverInfoFactory, LayerHoverInfoFactory];
+}

--- a/apps/frontend/src/components/keplerGl/factories/map/LayerHoverInfo.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/map/LayerHoverInfo.tsx
@@ -170,7 +170,7 @@ export interface LayerHoverInfoProps extends ExpandedProps {
   fieldsToShow: TooltipField[];
   layer: MapboxLayerGL;
   data: DataRow & {
-    points: any[];
+    points: [number, number][];
     elevationValue: string;
     colorValue: string;
   };

--- a/apps/frontend/src/components/keplerGl/factories/map/MapPopoverFactory.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/map/MapPopoverFactory.tsx
@@ -1,0 +1,274 @@
+// Try to keep imports in same order for a more readable diff.
+import React, { useEffect, useState } from 'react';
+import styled, { ThemeProvider } from 'styled-components';
+import classNames from 'classnames';
+import KeplerMapPopoverFactory from 'kepler.gl/dist/components/map/map-popover';
+import LayerHoverInfoFactory from 'kepler.gl/dist/components/map/layer-hover-info';
+import CoordinateInfoFactory from 'kepler.gl/dist/components/map/coordinate-info';
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  useHover,
+  useFocus,
+  useDismiss,
+  useRole,
+  useInteractions,
+  useClientPoint,
+  FloatingContext,
+  FloatingFocusManager,
+} from '@floating-ui/react';
+import { darkTheme } from '../../../../style/theme';
+import { LayerHoverInfoProps } from './LayerHoverInfo';
+
+const MAX_WIDTH = 500;
+const MAX_HEIGHT = 600;
+
+const StyledMapPopover = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: ${MAX_WIDTH}px;
+  max-height: ${MAX_HEIGHT}px;
+  padding: 22px;
+  & > * + * {
+    margin-top: 6px;
+  }
+  ${(props) => props.theme.scrollBar};
+  font-family: ${(props) => props.theme.fontFamily};
+  font-size: 11px;
+  font-weight: 500;
+  background-color: ${(props) => props.theme.panelBackground};
+  color: ${(props) => props.theme.textColor};
+  z-index: 1000;
+  overflow-x: auto;
+  box-shadow: ${(props) => props.theme.panelBoxShadow};
+
+  :hover {
+    background-color: ${(props) => `${props.theme.panelBackground}dd`};
+  }
+
+  .map-popover__layer-info,
+  .coordinate-hover-info {
+    & > * + * {
+      margin-top: 7px;
+    }
+  }
+
+  .map-popover__layer-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+
+    .map-popover__topbar {
+      display: none;
+      position: sticky;
+      top: 10px;
+      flex-direction: row;
+      justify-content: space-between;
+
+      .map-popover__layer-name {
+        font-family: 'Roboto', Verdana, 'Helvetica Neue', Helvetica, sans-serif;
+        font-size: 16px;
+      }
+
+      .button {
+        margin: 0;
+        background-color: initial;
+        font-size: 36px;
+      }
+    }
+
+    .map-popover__content {
+      padding-bottom: 13px;
+    }
+
+    .entry-info {
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Testing pure CSS solution. */
+    .row {
+      display: flex;
+      flex-direction: row;
+      gap: 10px;
+    }
+
+    .row:nth-child(1) .row__value,
+    .row .row__value h3 {
+      font-size: 32px;
+      text-transform: uppercase;
+      padding-bottom: 13px;
+      font-weight: 700;
+    }
+
+    .row.image-container {
+      justify-content: center;
+    }
+
+    // This doesn't work as you would expect.
+    // It targets the 5 first elements no matters what's in the not selector content.
+    .row:not(.empty, .image-container):nth-of-type(-n + 5) {
+    }
+
+    .row:nth-child(1) .row__name,
+    .row.image-container,
+    .row.empty,
+    .row:not(.empty, .image-container):nth-child(n + 5) {
+      display: none;
+    }
+
+    .row__name,
+    .row__value {
+      color: ${(props) => props.theme.textColorHl};
+      font-family: 'Roboto', Verdana, 'Helvetica Neue', Helvetica, sans-serif;
+      font-size: 16px;
+      line-height: 1.4;
+    }
+
+    .row__name {
+      color: ${(props) => props.theme.textColor};
+    }
+
+    .row__value {
+      text-align: left;
+      font-size: 16px;
+      font-weight: 500;
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2; /* number of lines to show */
+      line-clamp: 2;
+    }
+  }
+
+  &.expanded {
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    padding: 32px;
+    transition: transform 0.3s;
+
+    .row__value {
+      transition: all 0.3s;
+    }
+
+    .map-popover__layer-info {
+      .map-popover__topbar {
+        display: flex;
+      }
+
+      .row.image-container,
+      .row.empty,
+      .map-popover__content .row:nth-child(n + 5) {
+        display: flex;
+      }
+
+      .row__value {
+        -webkit-line-clamp: initial; /* number of lines to show */
+        line-clamp: initial;
+      }
+
+      .map-popover__actions {
+        display: none;
+      }
+    }
+  }
+`;
+
+const PopoverContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  & > * + * {
+    margin-top: 12px;
+  }
+`;
+
+interface UseMapPointOptions {
+  container: Element;
+  x: number;
+  y: number;
+  size?: number;
+  enabled: boolean;
+}
+
+const useMapPoint = (context: FloatingContext, { container, x, y, size = 0, enabled = true }: UseMapPointOptions) => {
+  const bounds = container && container.getBoundingClientRect ? container.getBoundingClientRect() : { left: 0, top: 0 };
+  const left = bounds.left + (enabled ? x : 0) - size / 2;
+  const top = bounds.top + (enabled ? y : 0) - size / 2;
+
+  return useClientPoint(context, { x: left, y: top });
+};
+
+interface MapPopoverProps {
+  x: number;
+  y: number;
+  frozen: boolean;
+  coordinate: never;
+  size: number;
+  enabled: boolean;
+  layerHoverProp: Omit<LayerHoverInfoProps, 'expanded' | 'setExpanded' | 'onClose'>;
+  isBase: boolean;
+  zoom: number;
+  container: Element;
+  onClose: () => void;
+}
+
+function MapPopoverFactory(LayerHoverInfo, CoordinateInfo) {
+  const MapPopover = ({ x, y, frozen, coordinate, layerHoverProp, zoom, container, onClose }: MapPopoverProps) => {
+    const [expanded, setExpanded] = useState<boolean>(false);
+    const { refs, floatingStyles, context } = useFloating({
+      open: true,
+      placement: expanded ? 'top-start' : 'bottom',
+      whileElementsMounted: autoUpdate,
+      middleware: [
+        expanded
+          ? offset(({ rects }) => {
+              return {
+                alignmentAxis: 0,
+                mainAxis: -rects.floating.height,
+              };
+            })
+          : offset(32),
+      ],
+    });
+    const hover = useHover(context, { move: false });
+    const focus = useFocus(context);
+    const dismiss = useDismiss(context);
+    const role = useRole(context, { role: 'tooltip' });
+    const clientPoint = useMapPoint(context, { container, x, y, enabled: !expanded });
+    const { getFloatingProps } = useInteractions([hover, focus, dismiss, role, clientPoint]);
+
+    useEffect(() => {
+      context.update();
+    }, [context, expanded, frozen]);
+
+    return (
+      <ThemeProvider theme={darkTheme}>
+        <FloatingFocusManager context={context} modal={frozen}>
+          <StyledMapPopover
+            className={classNames(['map-popover', expanded && 'expanded'])}
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+          >
+            <PopoverContent>
+              {Array.isArray(coordinate) && <CoordinateInfo coordinate={coordinate} zoom={zoom} />}
+              {layerHoverProp && (
+                <LayerHoverInfo {...layerHoverProp} expanded={expanded} setExpanded={setExpanded} onClose={onClose} />
+              )}
+            </PopoverContent>
+          </StyledMapPopover>
+        </FloatingFocusManager>
+      </ThemeProvider>
+    );
+  };
+  return MapPopover;
+}
+
+MapPopoverFactory.deps = [LayerHoverInfoFactory, CoordinateInfoFactory];
+
+export function replaceMapPopoverFactory() {
+  return [KeplerMapPopoverFactory, MapPopoverFactory];
+}

--- a/apps/frontend/src/components/keplerGl/injector.ts
+++ b/apps/frontend/src/components/keplerGl/injector.ts
@@ -24,11 +24,15 @@ import {
   provideMultiSelectFilter,
   replaceModalDialog,
 } from './factories';
+import { replaceLayerHoverInfoFactory } from './factories/map/LayerHoverInfo';
+import { replaceMapPopoverFactory } from './factories/map/MapPopoverFactory';
 
 // ⚠ Order matters ⚠
 export const appInjector = provideRecipesToInjector(
   [
     replaceKeplerGL(),
+    replaceMapPopoverFactory(),
+    replaceLayerHoverInfoFactory(),
     replaceModalDialog(),
     replacePanelHeader(),
     replacePanelToggleFactory(),

--- a/apps/frontend/src/store/effects.ts
+++ b/apps/frontend/src/store/effects.ts
@@ -46,6 +46,7 @@ startAppListening({
     ])
   ),
   effect: async (action, { dispatch, getState }) => {
+    console.log('action', action);
     const state = getState();
     if (!selectLoggedIn(state)) {
       return;

--- a/apps/frontend/src/store/index.ts
+++ b/apps/frontend/src/store/index.ts
@@ -32,7 +32,7 @@ const store = configureStore({
       }),
       process.env.NODE_ENV === 'development' &&
         createLogger({
-          diff: true,
+          diff: false, // diff might cause unexpected errors and mess with hot reload
           predicate: (getState, { type }) => !actionsBlacklist.includes(type),
           collapsed: (getState, action, logEntry) => !(logEntry && logEntry.error),
         }),

--- a/apps/frontend/src/style/theme.ts
+++ b/apps/frontend/src/style/theme.ts
@@ -1,4 +1,5 @@
 import { DIMENSIONS } from 'kepler.gl/dist/constants/default-settings';
+import { theme as keplerTheme } from 'kepler.gl/dist/styles/base';
 import {
   Input,
   InputLT,
@@ -248,3 +249,8 @@ export const theme = {
 
 export type DatatlasTheme = typeof theme;
 export type DatatlasThemeProps = ThemeProps<DatatlasTheme>;
+
+export const darkTheme = {
+  ...keplerTheme,
+  panelBackground: 'black',
+};

--- a/apps/frontend/src/utils/index.ts
+++ b/apps/frontend/src/utils/index.ts
@@ -1,0 +1,5 @@
+export * from './array';
+export * from './color';
+export * from './rtk';
+export * from './text';
+export * from './url';

--- a/apps/frontend/src/utils/text.ts
+++ b/apps/frontend/src/utils/text.ts
@@ -1,0 +1,5 @@
+export const humanize = (label: string) =>
+  label
+    .replace(/^[\s_]+|[\s_]+$/g, '')
+    .replace(/[_\s]+/g, ' ')
+    .replace(/^[a-z]/, (m) => m.toUpperCase());

--- a/apps/frontend/src/utils/url.ts
+++ b/apps/frontend/src/utils/url.ts
@@ -7,3 +7,5 @@ export const isValidHttpURL = (string: string) => {
   }
   return url.protocol === 'http:' || url.protocol === 'https:';
 };
+
+export const isImageURL = (url: string) => /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url);

--- a/libs/models/kepler/CompareType.ts
+++ b/libs/models/kepler/CompareType.ts
@@ -1,0 +1,4 @@
+export enum CompareType {
+  ABSOLUTE = 'absolute',
+  RELATIVE = 'relative',
+}

--- a/libs/models/kepler/index.ts
+++ b/libs/models/kepler/index.ts
@@ -1,3 +1,4 @@
+export * from './CompareType';
 export * from './DatasetFactory';
 export * from './DatatlasGlVisState';
 export * from './KeplerMapConfig';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@docusaurus/preset-classic": "^2.1.0",
         "@docusaurus/theme-common": "^2.2.0",
         "@docusaurus/theme-mermaid": "^2.2.0",
+        "@floating-ui/react": "^0.26.1",
         "@mdx-js/react": "^1.6.22",
         "@mikro-orm/core": "^5.6.8",
         "@mikro-orm/nestjs": "^5.1.6",
@@ -5400,6 +5401,54 @@
         "node": ">=14.0.0",
         "npm": ">=6.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.1.tgz",
+      "integrity": "sha512-5gyJIJ2tZOPMgmZ/vEcVhdmQiy75b7LPO71sYIiDsxGcZ4hxLuygQWCuT0YXHqppt//Eese+L6t5KnX/gZ3tVA==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.2",
+        "@floating-ui/utils": "^0.1.5",
+        "tabbable": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
     },
     "node_modules/@formatjs/cli": {
       "version": "6.0.4",
@@ -42113,6 +42162,11 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+    },
     "node_modules/tailwindcss": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
@@ -49787,6 +49841,46 @@
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
       "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
       "dev": true
+    },
+    "@floating-ui/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+      "requires": {
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "requires": {
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "@floating-ui/react": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.1.tgz",
+      "integrity": "sha512-5gyJIJ2tZOPMgmZ/vEcVhdmQiy75b7LPO71sYIiDsxGcZ4hxLuygQWCuT0YXHqppt//Eese+L6t5KnX/gZ3tVA==",
+      "requires": {
+        "@floating-ui/react-dom": "^2.0.2",
+        "@floating-ui/utils": "^0.1.5",
+        "tabbable": "^6.0.1"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "requires": {
+        "@floating-ui/dom": "^1.5.1"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
     },
     "@formatjs/cli": {
       "version": "6.0.4",
@@ -77168,6 +77262,11 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "tailwindcss": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@docusaurus/preset-classic": "^2.1.0",
     "@docusaurus/theme-common": "^2.2.0",
     "@docusaurus/theme-mermaid": "^2.2.0",
+    "@floating-ui/react": "^0.26.1",
     "@mdx-js/react": "^1.6.22",
     "@mikro-orm/core": "^5.6.8",
     "@mikro-orm/nestjs": "^5.1.6",


### PR DESCRIPTION
Add a detailed, fullscreen, view of all POI information. This view is accessible from a button in the tooltip of a POI.

This roughly implement rules described #249 but should be enough for testing the feature.

This also loosely implements @SeongHunChandra design, but will require some more hard work to get it right.