### PR TITLE
feat(resize): resize map when menu overflow

### DIFF
--- a/apps/frontend/src/components/KeplerMap.tsx
+++ b/apps/frontend/src/components/KeplerMap.tsx
@@ -1,39 +1,38 @@
-import React, { useEffect } from 'react';
-import { AutoSizer } from 'react-virtualized';
+import React, { RefObject, useContext, useEffect } from 'react';
 import { theme } from '../style/theme';
 import { KeplerGl } from './keplerGl';
 import { messages } from '../i18n/messages';
-import { useForward } from '../hooks/useForward';
+import { useForward, useMapAutoSizer } from '../hooks';
+import { MapControlRefContext } from './context/MapControlRefContext';
 import { updateReadState } from '../store/reducers/keplerGl';
 
 interface KeplerMapProps {
   id: string;
   readOnly: boolean;
+  mapContainerRef: RefObject<HTMLDivElement | undefined>;
 }
 
-const KeplerMap = ({ id, readOnly }: KeplerMapProps) => {
+const KeplerMap = ({ id, readOnly, mapContainerRef }: KeplerMapProps) => {
   const forward = useForward();
 
   useEffect(() => {
     forward(updateReadState(readOnly));
   }, [readOnly, forward]);
 
+  const mapControlRef = useContext(MapControlRefContext);
+  const dimensions = useMapAutoSizer<HTMLDivElement>(mapContainerRef, mapControlRef);
+
   return (
-    <AutoSizer>
-      {({ height, width }) => (
-        <KeplerGl
-          id={id}
-          width={width}
-          height={height}
-          mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_ACCESS_TOKEN || ''}
-          theme={theme}
-          appName={process.env.REACT_APP_NAME || 'Datatlas'}
-          mint={false}
-          localeMessages={messages}
-          readOnly={readOnly}
-        />
-      )}
-    </AutoSizer>
+    <KeplerGl
+      id={id}
+      {...dimensions}
+      mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_ACCESS_TOKEN || ''}
+      theme={theme}
+      appName={process.env.REACT_APP_NAME || 'Datatlas'}
+      mint={false}
+      localeMessages={messages}
+      readOnly={readOnly}
+    />
   );
 };
 

--- a/apps/frontend/src/components/context/MapControlRefContext.tsx
+++ b/apps/frontend/src/components/context/MapControlRefContext.tsx
@@ -1,0 +1,3 @@
+import { createContext, RefObject } from 'react';
+
+export const MapControlRefContext = createContext<RefObject<HTMLDivElement> | null | undefined>(null);

--- a/apps/frontend/src/components/keplerGl/factories/MapControlFactory.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/MapControlFactory.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks, @typescript-eslint/no-explicit-any */
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, useContext } from 'react';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
@@ -11,10 +11,11 @@ import { setFilter, layerConfigChange } from 'kepler.gl/dist/actions/vis-state-a
 import { KeplerGLProps } from './KeplerGlFactory';
 import { MapMenu } from '../../map-menu';
 import { RootState } from '../../../store/reducers';
-import { useForward } from '../../../hooks/useForward';
+import { useForward } from '../../../hooks';
 import { selectFilters, selectFiltersConfig } from '../../../store/selectors';
 import { FiltersConfigInterface } from '@datatlas/models';
 import { PublishButton } from '../../buttons/PublishButton';
+import { MapControlRefContext } from '../../context/MapControlRefContext';
 
 const StyledMapControl = styled.div<Pick<MapControlProps, 'theme' | 'top'>>`
   right: 0;
@@ -61,12 +62,13 @@ function MapControlFactory(MapDrawPanel, Toggle3dButton) {
       return null;
     }
 
+    const mapControlRef = useContext(MapControlRefContext);
     const forward = useForward();
     const filters = useSelector<RootState, Filter[]>((state) => selectFilters(state, id));
     const filtersConfig = useSelector<RootState, FiltersConfigInterface>((state) => selectFiltersConfig(state, id));
 
     return (
-      <StyledMapControl className="map-control" top={top} role="menubar">
+      <StyledMapControl className="map-control" top={top} role="menubar" ref={mapControlRef}>
         <MapMenu
           role="toolbar"
           datasets={datasets}

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useFetchUser';
 export * from './useForward';
 export * from './useIsMobile';
+export * from './useMapAutoSizer';
 export * from './useTimeElapsed';

--- a/apps/frontend/src/hooks/useMapAutoSizer.ts
+++ b/apps/frontend/src/hooks/useMapAutoSizer.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useMemo, RefObject } from 'react';
+import debounce from 'lodash.debounce';
+
+interface Dimensions {
+  height: number;
+  width: number;
+}
+
+const getEntryOuterHeight = (entry: ResizeObserverEntry) =>
+  entry.borderBoxSize?.[0].blockSize || entry.contentRect.height;
+
+export const useMapAutoSizer = <E extends HTMLElement>(
+  containerRef: RefObject<E | undefined>,
+  mapControlRef: RefObject<HTMLDivElement> | undefined | null
+): Dimensions => {
+  const [dimensions, setDimensions] = useState<Dimensions>({ width: 0, height: 0 });
+  const [mapControlHeight, setMapControlHeight] = useState<Dimensions['height']>(0);
+  const observer = useMemo(
+    () =>
+      new ResizeObserver(
+        debounce(
+          (entries: ResizeObserverEntry[]) => {
+            for (const entry of entries) {
+              if (entry.target.classList.contains('map-control')) {
+                setMapControlHeight(getEntryOuterHeight(entry));
+              } else if (entry.target.classList.contains('map-container')) {
+                const { width, height } = entry.contentRect;
+                setDimensions({ width, height });
+              }
+            }
+          },
+          300,
+          { leading: true, trailing: true }
+        )
+      ),
+    []
+  );
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    observer.observe(containerRef.current);
+
+    if (mapControlRef?.current) {
+      observer.observe(mapControlRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [containerRef, mapControlRef, observer]);
+
+  return { ...dimensions, height: mapControlHeight > dimensions.height ? mapControlHeight : dimensions.height };
+};

--- a/apps/frontend/src/pages/ProjectPage.tsx
+++ b/apps/frontend/src/pages/ProjectPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { createRef, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
@@ -9,6 +9,7 @@ import { getUser, useGetProjectQuery } from '../store/api';
 import { Loader } from '../components/Loader';
 import { selectCurrentUserId } from '../store/selectors';
 import { ErrorComponent } from '../components/ErrorComponent';
+import { MapControlRefContext } from '../components/context/MapControlRefContext';
 
 const MapContainer = styled.div`
   position: relative;
@@ -42,6 +43,8 @@ export const ProjectPage = () => {
     data: project,
   } = useGetProjectQuery(+id ?? skipToken);
   const isLoading = isUserLoading || isUserFetching || isProjectLoading || isProjectFetching;
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+  const mapControlRef = createRef<HTMLDivElement>();
 
   if (isLoading) {
     return (
@@ -54,8 +57,14 @@ export const ProjectPage = () => {
   }
 
   return (
-    <MapContainer>
-      <KeplerMap id={id} readOnly={!Project.canProjectDtoBeEditedBy(project, user)} />
+    <MapContainer className="map-container" ref={mapContainerRef}>
+      <MapControlRefContext.Provider value={mapControlRef}>
+        <KeplerMap
+          id={id}
+          readOnly={!Project.canProjectDtoBeEditedBy(project, user)}
+          mapContainerRef={mapContainerRef}
+        />
+      </MapControlRefContext.Provider>
     </MapContainer>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "classnames": "^2.3.2",
         "core-js": "^3.6.5",
         "kepler.gl": "^2.5.5",
+        "lodash.debounce": "^4.0.8",
         "luxon": "^3.2.1",
         "msw": "^0.49.2",
         "passport": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "classnames": "^2.3.2",
     "core-js": "^3.6.5",
     "kepler.gl": "^2.5.5",
+    "lodash.debounce": "^4.0.8",
     "luxon": "^3.2.1",
     "msw": "^0.49.2",
     "passport": "^0.6.0",


### PR DESCRIPTION
This is a fix proposition for #279.

I didn't find any trivial CSS solution.
This reimplements the "auto sizer" behavior via a native resize observer, and it adds a special case when the map control menu is longer than the map canvas. Resize observer callback is debounced to avoid too many updates.

This solution is far from perfect :
- there's an odd behavior with the footer disappearing when using the map control height for sizing
- when the height of the canvas is changing so is the central point, I don't know yet how to tackle this.
This will require some clever conversion from/to screen coordinates and map coordinates.