### PR TITLE
feat(map-popover): refine POI modal display

### DIFF
--- a/apps/frontend/src/components/DeleteProjectModal.tsx
+++ b/apps/frontend/src/components/DeleteProjectModal.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { css } from 'styled-components';
 import { LoadingProjectInterface, ProjectInterface } from '@datatlas/models';
-import document from 'global/document';
 import KeyEvent from 'kepler.gl/dist/constants/keyevent';
 import { StyledModal } from './Modal';
+import { useOnKeyEffect } from '../hooks/useOnKeyEffect';
 
 const smallModalCss = css`
   width: 40%;
@@ -17,20 +17,7 @@ interface DeleteProjectModalProps {
 }
 
 export const DeleteProjectModal = ({ project, onDelete, setDeletingProject }: DeleteProjectModalProps) => {
-  useEffect(() => {
-    const onKeyUp = (e: KeyEvent) => {
-      const keyCode = e.keyCode;
-      if (keyCode === KeyEvent.DOM_VK_ESCAPE) {
-        setDeletingProject(null);
-      }
-    };
-
-    document.addEventListener('keyup', onKeyUp);
-
-    return () => {
-      document.removeEventListener('keyup', onKeyUp);
-    };
-  }, [setDeletingProject]);
+  useOnKeyEffect<typeof project>(KeyEvent.DOM_VK_ESCAPE, setDeletingProject, null);
 
   const handleCloseModal = () => {
     setDeletingProject(null);

--- a/apps/frontend/src/components/keplerGl/factories/map/LayerHoverInfo.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/map/LayerHoverInfo.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import classNames from 'classnames';
 import { Layers } from 'kepler.gl/dist/components/common/icons';
@@ -14,6 +14,8 @@ import { CompareType } from '@datatlas/models';
 import { Button, OutlineButton } from '../../../buttons';
 import { ExternalLink } from '../../../ExternalLink';
 import { isImageURL, humanize } from '../../../../utils';
+import { useOnKeyEffect } from '../../../../hooks/useOnKeyEffect';
+import KeyEvent from 'kepler.gl/dist/constants/keyevent';
 
 export const MapPopoverContent = styled.div`
   & .row__delta-value {
@@ -51,8 +53,14 @@ export const Row = ({ name, value, deltaValue, url, aggregated, setExpandable }:
 
   // @todo We could also attempt to load the URL and see what's the content type.
   const asImg = /<img>/.test(name) || isImageURL(value as string);
+
+  useEffect(() => {
+    if (asImg) {
+      setExpandable(true);
+    }
+  }, [asImg, setExpandable]);
+
   if (asImg) {
-    setExpandable(true);
     return (
       <div {...containerProps} className={classNames([className, 'image-container'])}>
         <ExternalLink href={url}>
@@ -211,6 +219,8 @@ const LayerHoverInfoFactory = () => {
       return null;
     }
 
+    useOnKeyEffect<boolean>(KeyEvent.DOM_VK_ESCAPE, setExpanded, false);
+
     return (
       <LayerHoverInfoContainer
         className={classNames(['map-popover__layer-info', expanded && 'expanded'])}
@@ -223,7 +233,6 @@ const LayerHoverInfoFactory = () => {
           </StyledLayerName>
           <Button onClick={() => setExpanded(false)}>×</Button>
         </Toolbar>
-
         <MapPopoverContent className="map-popover__content">
           {props.layer.isAggregated ? (
             <CellInfo {...props} expanded={expanded} />

--- a/apps/frontend/src/components/keplerGl/factories/map/MapPopoverFactory.tsx
+++ b/apps/frontend/src/components/keplerGl/factories/map/MapPopoverFactory.tsx
@@ -39,6 +39,7 @@ const StyledMapPopover = styled.div`
 
   &.expanded {
     height: 100%;
+    max-height: 100%;
   }
 `;
 
@@ -111,7 +112,7 @@ const PopoverContent = styled.div<{ expandable: boolean; maxTooltipFields: numbe
     .row {
       display: flex;
       flex-direction: row;
-      gap: 10px;
+      gap: 13px;
       padding-bottom: 3px;
     }
 
@@ -127,6 +128,10 @@ const PopoverContent = styled.div<{ expandable: boolean; maxTooltipFields: numbe
       padding: 13px 0;
       justify-content: center;
       overflow: hidden;
+
+      img {
+        max-width: 100%;
+      }
     }
 
     // This doesn't work as you would expect.
@@ -176,6 +181,7 @@ const PopoverContent = styled.div<{ expandable: boolean; maxTooltipFields: numbe
     .row {
       flex-direction: column;
       gap: 0;
+      padding-bottom: 13px;
     }
 
     .row__value {
@@ -185,11 +191,15 @@ const PopoverContent = styled.div<{ expandable: boolean; maxTooltipFields: numbe
     .map-popover__layer-info {
       .map-popover__topbar {
         display: flex;
+        background-color: rgba(0, 0, 0, 0.5);
+      }
+
+      .map-popover__content .row.empty {
+        display: none;
       }
 
       .row.image-container,
-      .row.empty,
-      .map-popover__content .row:nth-child(n + ${({ maxTooltipFields }) => maxTooltipFields + 1}) {
+      .map-popover__content .row:not(.empty):nth-child(n + ${({ maxTooltipFields }) => maxTooltipFields + 1}) {
         display: flex;
       }
 

--- a/apps/frontend/src/hooks/useOnKeyEffect.ts
+++ b/apps/frontend/src/hooks/useOnKeyEffect.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import KeyEvent from 'kepler.gl/dist/constants/keyevent';
+
+export const useOnKeyEffect = <T>(keyCodeToListenTo: string, callback: (arg0: T) => void, callbackValue: T) =>
+  useEffect(() => {
+    const onKeyUp = (e: KeyEvent) => {
+      const keyCode = e.keyCode;
+      if (keyCode === keyCodeToListenTo) {
+        callback(callbackValue);
+      }
+    };
+
+    document.addEventListener('keyup', onKeyUp);
+
+    return () => {
+      document.removeEventListener('keyup', onKeyUp);
+    };
+  }, [keyCodeToListenTo, callback, callbackValue]);


### PR DESCRIPTION
- hide empty rows
- preserve image ratio on bigger images
- use full height on detailed view
- more spacing between rows on detailed view